### PR TITLE
Linear read mode: Delete old iterations

### DIFF
--- a/docs/source/dev/design.rst
+++ b/docs/source/dev/design.rst
@@ -23,7 +23,7 @@ Therefore, enabling users to handle hierarchical, self-describing file formats w
 
 .. literalinclude:: IOTask.hpp
    :language: cpp
-   :lines: 44-62
+   :lines: 48-78
 
 Every task is designed to be a fully self-contained description of one such atomic operation. By describing a required minimal step of work (without any side-effect), these operations are the foundation of the unified handling mechanism across suitable file formats.
 The actual low-level exchange of data is implemented in ``IOHandlers``, one per file format (possibly two if handlingi MPI-parallel work is possible and requires different behaviour).

--- a/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/ADIOS2IOHandler.hpp
@@ -213,6 +213,10 @@ public:
 
     void availableChunks(
         Writable *, Parameter<Operation::AVAILABLE_CHUNKS> &) override;
+
+    void
+    deregister(Writable *, Parameter<Operation::DEREGISTER> const &) override;
+
     /**
      * @brief The ADIOS2 access type to chose for Engines opened
      * within this instance.

--- a/include/openPMD/IO/ADIOS/CommonADIOS1IOHandler.hpp
+++ b/include/openPMD/IO/ADIOS/CommonADIOS1IOHandler.hpp
@@ -84,6 +84,8 @@ public:
     void
     listDatasets(Writable *, Parameter<Operation::LIST_DATASETS> &) override;
     void listAttributes(Writable *, Parameter<Operation::LIST_ATTS> &) override;
+    void
+    deregister(Writable *, Parameter<Operation::DEREGISTER> const &) override;
 
     void close(int64_t);
     void close(ADIOS_FILE *);

--- a/include/openPMD/IO/AbstractIOHandlerImpl.hpp
+++ b/include/openPMD/IO/AbstractIOHandlerImpl.hpp
@@ -202,6 +202,12 @@ public:
                         deref_dynamic_cast<Parameter<O::KEEP_SYNCHRONOUS> >(
                             i.parameter.get()));
                     break;
+                case O::DEREGISTER:
+                    deregister(
+                        i.writable,
+                        deref_dynamic_cast<Parameter<O::DEREGISTER> >(
+                            i.parameter.get()));
+                    break;
                 }
             }
             catch (...)
@@ -565,6 +571,16 @@ public:
      */
     void
     keepSynchronous(Writable *, Parameter<Operation::KEEP_SYNCHRONOUS> param);
+
+    /** Notify the backend that the Writable has been / will be deallocated.
+     *
+     * The backend should remove all references to this Writable from internal
+     * data structures. Subtle bugs might be possible if not doing this, since
+     * new objects might be allocated to the now-freed address.
+     * The Writable pointer must not be dereferenced.
+     */
+    virtual void
+    deregister(Writable *, Parameter<Operation::DEREGISTER> const &param) = 0;
 
     AbstractIOHandler *m_handler;
 }; // AbstractIOHandlerImpl

--- a/include/openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp
+++ b/include/openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp
@@ -75,6 +75,8 @@ public:
     void
     listDatasets(Writable *, Parameter<Operation::LIST_DATASETS> &) override;
     void listAttributes(Writable *, Parameter<Operation::LIST_ATTS> &) override;
+    void
+    deregister(Writable *, Parameter<Operation::DEREGISTER> const &) override;
 
     std::unordered_map<Writable *, std::string> m_fileNames;
     std::unordered_map<std::string, hid_t> m_fileNamesWithID;

--- a/include/openPMD/IO/IOTask.hpp
+++ b/include/openPMD/IO/IOTask.hpp
@@ -27,6 +27,7 @@
 #include "openPMD/auxiliary/Export.hpp"
 #include "openPMD/auxiliary/Variant.hpp"
 #include "openPMD/backend/Attribute.hpp"
+#include "openPMD/backend/ParsePreference.hpp"
 
 #include <map>
 #include <memory>
@@ -170,11 +171,7 @@ struct OPENPMDAPI_EXPORT Parameter<Operation::OPEN_FILE>
      * variableBased encoding.
      */
     IterationEncoding encoding = IterationEncoding::groupBased;
-    enum class ParsePreference : char
-    {
-        UpFront, //<! Data should be parsed right when opening the dataset
-        PerStep //<! Data should be parsed step by step
-    };
+    using ParsePreference = internal::ParsePreference;
     std::shared_ptr<ParsePreference> out_parsePreference =
         std::make_shared<ParsePreference>(ParsePreference::UpFront);
 };

--- a/include/openPMD/IO/IOTask.hpp
+++ b/include/openPMD/IO/IOTask.hpp
@@ -45,21 +45,37 @@ Writable *getWritable(Attributable *);
 /** Type of IO operation between logical and persistent data.
  */
 OPENPMDAPI_EXPORT_ENUM_CLASS(Operation){
-    CREATE_FILE,      CHECK_FILE,     OPEN_FILE,     CLOSE_FILE,
+    CREATE_FILE,
+    CHECK_FILE,
+    OPEN_FILE,
+    CLOSE_FILE,
     DELETE_FILE,
 
-    CREATE_PATH,      CLOSE_PATH,     OPEN_PATH,     DELETE_PATH,
+    CREATE_PATH,
+    CLOSE_PATH,
+    OPEN_PATH,
+    DELETE_PATH,
     LIST_PATHS,
 
-    CREATE_DATASET,   EXTEND_DATASET, OPEN_DATASET,  DELETE_DATASET,
-    WRITE_DATASET,    READ_DATASET,   LIST_DATASETS, GET_BUFFER_VIEW,
+    CREATE_DATASET,
+    EXTEND_DATASET,
+    OPEN_DATASET,
+    DELETE_DATASET,
+    WRITE_DATASET,
+    READ_DATASET,
+    LIST_DATASETS,
+    GET_BUFFER_VIEW,
 
-    DELETE_ATT,       WRITE_ATT,      READ_ATT,      LIST_ATTS,
+    DELETE_ATT,
+    WRITE_ATT,
+    READ_ATT,
+    LIST_ATTS,
 
     ADVANCE,
     AVAILABLE_CHUNKS, //!< Query chunks that can be loaded in a dataset
-    KEEP_SYNCHRONOUS //!< Keep two items in the object model synchronous with
-                     //!< each other
+    KEEP_SYNCHRONOUS, //!< Keep two items in the object model synchronous with
+                      //!< each other
+    DEREGISTER //!< Inform the backend that an object has been deleted.
 }; // note: if you change the enum members here, please update
    // docs/source/dev/design.rst
 
@@ -678,6 +694,20 @@ struct OPENPMDAPI_EXPORT Parameter<Operation::KEEP_SYNCHRONOUS>
     }
 
     Writable *otherWritable;
+};
+
+template <>
+struct OPENPMDAPI_EXPORT Parameter<Operation::DEREGISTER>
+    : public AbstractParameter
+{
+    Parameter() = default;
+    Parameter(Parameter const &) : AbstractParameter()
+    {}
+
+    std::unique_ptr<AbstractParameter> clone() const override
+    {
+        return std::make_unique<Parameter<Operation::DEREGISTER>>(*this);
+    }
 };
 
 /** @brief Self-contained description of a single IO operation.

--- a/include/openPMD/IO/JSON/JSONIOHandlerImpl.hpp
+++ b/include/openPMD/IO/JSON/JSONIOHandlerImpl.hpp
@@ -212,6 +212,9 @@ public:
 
     void listAttributes(Writable *, Parameter<Operation::LIST_ATTS> &) override;
 
+    void
+    deregister(Writable *, Parameter<Operation::DEREGISTER> const &) override;
+
     std::future<void> flush();
 
 private:

--- a/include/openPMD/Iteration.hpp
+++ b/include/openPMD/Iteration.hpp
@@ -31,6 +31,7 @@
 #include <cstdint>
 #include <deque>
 #include <optional>
+#include <set>
 #include <tuple>
 
 namespace openPMD
@@ -338,8 +339,11 @@ private:
      * Useful in group-based iteration encoding where the Iteration will only
      * be known after opening the step.
      */
-    static BeginStepStatus
-    beginStep(std::optional<Iteration> thisObject, Series &series, bool reread);
+    static BeginStepStatus beginStep(
+        std::optional<Iteration> thisObject,
+        Series &series,
+        bool reread,
+        std::set<IterationIndex_t> const &ignoreIterations = {});
 
     /**
      * @brief End an IO step on the IO file (or file-like object)

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -30,6 +30,7 @@
 #include "openPMD/auxiliary/Variant.hpp"
 #include "openPMD/backend/Attributable.hpp"
 #include "openPMD/backend/Container.hpp"
+#include "openPMD/backend/ParsePreference.hpp"
 #include "openPMD/config.hpp"
 #include "openPMD/version.hpp"
 
@@ -158,6 +159,14 @@ namespace internal
          * The destructor will only attempt flushing again if this is true.
          */
         bool m_lastFlushSuccessful = false;
+
+        /**
+         * Remember the preference that the backend specified for parsing.
+         * Not used in file-based iteration encoding, empty then.
+         * In linear read mode, parsing only starts after calling
+         * Series::readIterations(), empty before that point.
+         */
+        std::optional<ParsePreference> m_parsePreference;
 
         void close();
     }; // SeriesData
@@ -618,8 +627,10 @@ OPENPMD_private
      * ReadIterations since those methods should be aware when the current step
      * is broken).
      */
-    std::optional<std::deque<IterationIndex_t> >
-    readGorVBased(bool do_always_throw_errors, bool init);
+    std::optional<std::deque<IterationIndex_t> > readGorVBased(
+        bool do_always_throw_errors,
+        bool init,
+        std::set<IterationIndex_t> const &ignoreIterations = {});
     void readBase();
     std::string iterationFilename(IterationIndex_t i);
 

--- a/include/openPMD/backend/ParsePreference.hpp
+++ b/include/openPMD/backend/ParsePreference.hpp
@@ -1,0 +1,31 @@
+/* Copyright 2023 Franz Poeschel
+ *
+ * This file is part of openPMD-api.
+ *
+ * openPMD-api is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * openPMD-api is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with openPMD-api.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace openPMD::internal
+{
+enum class ParsePreference : char
+{
+    UpFront, //<! Data should be parsed right when opening the dataset
+    PerStep //<! Data should be parsed step by step
+};
+} // namespace openPMD::internal

--- a/include/openPMD/backend/Writable.hpp
+++ b/include/openPMD/backend/Writable.hpp
@@ -97,7 +97,7 @@ private:
     Writable(internal::AttributableData *);
 
 public:
-    ~Writable() = default;
+    ~Writable();
 
     Writable(Writable const &other) = delete;
     Writable(Writable &&other) = delete;

--- a/src/IO/ADIOS/ADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS1IOHandler.cpp
@@ -102,49 +102,55 @@ std::future<void> ADIOS1IOHandlerImpl::flush()
             case O::CREATE_FILE:
                 createFile(
                     i.writable,
-                    deref_dynamic_cast<Parameter<Operation::CREATE_FILE> >(
+                    deref_dynamic_cast<Parameter<Operation::CREATE_FILE>>(
                         i.parameter.get()));
                 break;
             case O::CHECK_FILE:
                 checkFile(
                     i.writable,
-                    deref_dynamic_cast<Parameter<Operation::CHECK_FILE> >(
+                    deref_dynamic_cast<Parameter<Operation::CHECK_FILE>>(
                         i.parameter.get()));
                 break;
             case O::CREATE_PATH:
                 createPath(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::CREATE_PATH> >(
+                    deref_dynamic_cast<Parameter<O::CREATE_PATH>>(
                         i.parameter.get()));
                 break;
             case O::OPEN_PATH:
                 openPath(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::OPEN_PATH> >(
+                    deref_dynamic_cast<Parameter<O::OPEN_PATH>>(
                         i.parameter.get()));
                 break;
             case O::CREATE_DATASET:
                 createDataset(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::CREATE_DATASET> >(
+                    deref_dynamic_cast<Parameter<O::CREATE_DATASET>>(
                         i.parameter.get()));
                 break;
             case O::WRITE_ATT:
                 writeAttribute(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::WRITE_ATT> >(
+                    deref_dynamic_cast<Parameter<O::WRITE_ATT>>(
                         i.parameter.get()));
                 break;
             case O::OPEN_FILE:
                 openFile(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::OPEN_FILE> >(
+                    deref_dynamic_cast<Parameter<O::OPEN_FILE>>(
                         i.parameter.get()));
                 break;
             case O::KEEP_SYNCHRONOUS:
                 keepSynchronous(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::KEEP_SYNCHRONOUS> >(
+                    deref_dynamic_cast<Parameter<O::KEEP_SYNCHRONOUS>>(
+                        i.parameter.get()));
+                break;
+            case O::DEREGISTER:
+                deregister(
+                    i.writable,
+                    deref_dynamic_cast<Parameter<O::DEREGISTER>>(
                         i.parameter.get()));
                 break;
             default:
@@ -183,19 +189,19 @@ std::future<void> ADIOS1IOHandlerImpl::flush()
             case O::EXTEND_DATASET:
                 extendDataset(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::EXTEND_DATASET> >(
+                    deref_dynamic_cast<Parameter<O::EXTEND_DATASET>>(
                         i.parameter.get()));
                 break;
             case O::CLOSE_PATH:
                 closePath(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::CLOSE_PATH> >(
+                    deref_dynamic_cast<Parameter<O::CLOSE_PATH>>(
                         i.parameter.get()));
                 break;
             case O::OPEN_DATASET:
                 openDataset(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::OPEN_DATASET> >(
+                    deref_dynamic_cast<Parameter<O::OPEN_DATASET>>(
                         i.parameter.get()));
                 break;
             case O::CLOSE_FILE:
@@ -207,79 +213,79 @@ std::future<void> ADIOS1IOHandlerImpl::flush()
             case O::DELETE_FILE:
                 deleteFile(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::DELETE_FILE> >(
+                    deref_dynamic_cast<Parameter<O::DELETE_FILE>>(
                         i.parameter.get()));
                 break;
             case O::DELETE_PATH:
                 deletePath(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::DELETE_PATH> >(
+                    deref_dynamic_cast<Parameter<O::DELETE_PATH>>(
                         i.parameter.get()));
                 break;
             case O::DELETE_DATASET:
                 deleteDataset(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::DELETE_DATASET> >(
+                    deref_dynamic_cast<Parameter<O::DELETE_DATASET>>(
                         i.parameter.get()));
                 break;
             case O::DELETE_ATT:
                 deleteAttribute(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::DELETE_ATT> >(
+                    deref_dynamic_cast<Parameter<O::DELETE_ATT>>(
                         i.parameter.get()));
                 break;
             case O::WRITE_DATASET:
                 writeDataset(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::WRITE_DATASET> >(
+                    deref_dynamic_cast<Parameter<O::WRITE_DATASET>>(
                         i.parameter.get()));
                 break;
             case O::READ_DATASET:
                 readDataset(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::READ_DATASET> >(
+                    deref_dynamic_cast<Parameter<O::READ_DATASET>>(
                         i.parameter.get()));
                 break;
             case O::GET_BUFFER_VIEW:
                 getBufferView(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::GET_BUFFER_VIEW> >(
+                    deref_dynamic_cast<Parameter<O::GET_BUFFER_VIEW>>(
                         i.parameter.get()));
                 break;
             case O::READ_ATT:
                 readAttribute(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::READ_ATT> >(
+                    deref_dynamic_cast<Parameter<O::READ_ATT>>(
                         i.parameter.get()));
                 break;
             case O::LIST_PATHS:
                 listPaths(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::LIST_PATHS> >(
+                    deref_dynamic_cast<Parameter<O::LIST_PATHS>>(
                         i.parameter.get()));
                 break;
             case O::LIST_DATASETS:
                 listDatasets(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::LIST_DATASETS> >(
+                    deref_dynamic_cast<Parameter<O::LIST_DATASETS>>(
                         i.parameter.get()));
                 break;
             case O::LIST_ATTS:
                 listAttributes(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::LIST_ATTS> >(
+                    deref_dynamic_cast<Parameter<O::LIST_ATTS>>(
                         i.parameter.get()));
                 break;
             case O::ADVANCE:
                 advance(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::ADVANCE> >(
+                    deref_dynamic_cast<Parameter<O::ADVANCE>>(
                         i.parameter.get()));
                 break;
             case O::AVAILABLE_CHUNKS:
                 availableChunks(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::AVAILABLE_CHUNKS> >(
+                    deref_dynamic_cast<Parameter<O::AVAILABLE_CHUNKS>>(
                         i.parameter.get()));
                 break;
             default:
@@ -366,6 +372,7 @@ void ADIOS1IOHandler::enqueue(IOTask const &i)
     case Operation::OPEN_FILE:
     case Operation::WRITE_ATT:
     case Operation::KEEP_SYNCHRONOUS:
+    case Operation::DEREGISTER:
         m_setup.push(i);
         return;
     default:

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -614,7 +614,7 @@ void ADIOS2IOHandlerImpl::createDataset(
         std::string name = auxiliary::removeSlashes(parameters.name);
 
         auto const file =
-            refreshFileFromParent(writable, /* preferParentFile = */ false);
+            refreshFileFromParent(writable, /* preferParentFile = */ true);
         auto filePos = setAndGetFilePosition(writable, name);
         filePos->gd = ADIOS2FilePosition::GD::DATASET;
         auto const varName = nameOfVariable(writable);
@@ -777,7 +777,7 @@ void ADIOS2IOHandlerImpl::openDataset(
     writable->abstractFilePosition.reset();
     auto pos = setAndGetFilePosition(writable, name);
     pos->gd = ADIOS2FilePosition::GD::DATASET;
-    auto file = refreshFileFromParent(writable, /* preferParentFile = */ false);
+    auto file = refreshFileFromParent(writable, /* preferParentFile = */ true);
     auto varName = nameOfVariable(writable);
     *parameters.dtype =
         detail::fromADIOS2Type(getFileData(file, IfFileNotOpen::ThrowError)
@@ -1271,7 +1271,7 @@ void ADIOS2IOHandlerImpl::listAttributes(
 void ADIOS2IOHandlerImpl::advance(
     Writable *writable, Parameter<Operation::ADVANCE> &parameters)
 {
-    auto file = m_files[writable];
+    auto file = m_files.at(writable);
     auto &ba = getFileData(file, IfFileNotOpen::ThrowError);
     *parameters.status =
         ba.advance(parameters.mode, /* calledExplicitly = */ true);

--- a/src/IO/ADIOS/ADIOS2IOHandler.cpp
+++ b/src/IO/ADIOS/ADIOS2IOHandler.cpp
@@ -748,6 +748,8 @@ void ADIOS2IOHandlerImpl::closeFile(
                 /* flushUnconditionally = */ false);
             m_fileData.erase(it);
         }
+        m_dirty.erase(fileIterator->second);
+        m_files.erase(fileIterator);
     }
 }
 
@@ -1326,6 +1328,12 @@ void ADIOS2IOHandlerImpl::availableChunks(
         engine,
         varName,
         /* allSteps = */ allSteps);
+}
+
+void ADIOS2IOHandlerImpl::deregister(
+    Writable *writable, Parameter<Operation::DEREGISTER> const &)
+{
+    m_files.erase(writable);
 }
 
 adios2::Mode ADIOS2IOHandlerImpl::adios2AccessMode(std::string const &fullPath)

--- a/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
@@ -1986,6 +1986,13 @@ void CommonADIOS1IOHandlerImpl<ChildClass>::listAttributes(
 }
 
 template <typename ChildClass>
+void CommonADIOS1IOHandlerImpl<ChildClass>::deregister(
+    Writable *writable, Parameter<Operation::DEREGISTER> const &)
+{
+    m_filePaths.erase(writable);
+}
+
+template <typename ChildClass>
 void CommonADIOS1IOHandlerImpl<ChildClass>::initJson(json::TracingJSON config)
 {
     if (!config.json().contains("adios1"))

--- a/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/CommonADIOS1IOHandler.cpp
@@ -533,9 +533,7 @@ void CommonADIOS1IOHandlerImpl<ChildClass>::createDataset(
     {
         /* ADIOS variable definitions require the file to be (re-)opened to take
          * effect/not cause errors */
-        auto res = m_filePaths.find(writable);
-        if (res == m_filePaths.end())
-            res = m_filePaths.find(writable->parent);
+        auto res = m_filePaths.find(writable->parent);
 
         int64_t group = m_groups[res->second];
 
@@ -839,9 +837,7 @@ void CommonADIOS1IOHandlerImpl<ChildClass>::openDataset(
     Writable *writable, Parameter<Operation::OPEN_DATASET> &parameters)
 {
     ADIOS_FILE *f;
-    auto res = m_filePaths.find(writable);
-    if (res == m_filePaths.end())
-        res = m_filePaths.find(writable->parent);
+    auto res = m_filePaths.find(writable->parent);
     f = m_openReadFileHandles.at(res->second);
 
     /* Sanitize name */

--- a/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
+++ b/src/IO/ADIOS/ParallelADIOS1IOHandler.cpp
@@ -123,49 +123,55 @@ std::future<void> ParallelADIOS1IOHandlerImpl::flush()
             case O::CREATE_FILE:
                 createFile(
                     i.writable,
-                    deref_dynamic_cast<Parameter<Operation::CREATE_FILE> >(
+                    deref_dynamic_cast<Parameter<Operation::CREATE_FILE>>(
                         i.parameter.get()));
                 break;
             case O::CHECK_FILE:
                 checkFile(
                     i.writable,
-                    deref_dynamic_cast<Parameter<Operation::CHECK_FILE> >(
+                    deref_dynamic_cast<Parameter<Operation::CHECK_FILE>>(
                         i.parameter.get()));
                 break;
             case O::CREATE_PATH:
                 createPath(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::CREATE_PATH> >(
+                    deref_dynamic_cast<Parameter<O::CREATE_PATH>>(
                         i.parameter.get()));
                 break;
             case O::OPEN_PATH:
                 openPath(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::OPEN_PATH> >(
+                    deref_dynamic_cast<Parameter<O::OPEN_PATH>>(
                         i.parameter.get()));
                 break;
             case O::CREATE_DATASET:
                 createDataset(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::CREATE_DATASET> >(
+                    deref_dynamic_cast<Parameter<O::CREATE_DATASET>>(
                         i.parameter.get()));
                 break;
             case O::WRITE_ATT:
                 writeAttribute(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::WRITE_ATT> >(
+                    deref_dynamic_cast<Parameter<O::WRITE_ATT>>(
                         i.parameter.get()));
                 break;
             case O::OPEN_FILE:
                 openFile(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::OPEN_FILE> >(
+                    deref_dynamic_cast<Parameter<O::OPEN_FILE>>(
                         i.parameter.get()));
                 break;
             case O::KEEP_SYNCHRONOUS:
                 keepSynchronous(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::KEEP_SYNCHRONOUS> >(
+                    deref_dynamic_cast<Parameter<O::KEEP_SYNCHRONOUS>>(
+                        i.parameter.get()));
+                break;
+            case O::DEREGISTER:
+                deregister(
+                    i.writable,
+                    deref_dynamic_cast<Parameter<O::DEREGISTER>>(
                         i.parameter.get()));
                 break;
             default:
@@ -202,19 +208,19 @@ std::future<void> ParallelADIOS1IOHandlerImpl::flush()
             case O::EXTEND_DATASET:
                 extendDataset(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::EXTEND_DATASET> >(
+                    deref_dynamic_cast<Parameter<O::EXTEND_DATASET>>(
                         i.parameter.get()));
                 break;
             case O::CLOSE_PATH:
                 closePath(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::CLOSE_PATH> >(
+                    deref_dynamic_cast<Parameter<O::CLOSE_PATH>>(
                         i.parameter.get()));
                 break;
             case O::OPEN_DATASET:
                 openDataset(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::OPEN_DATASET> >(
+                    deref_dynamic_cast<Parameter<O::OPEN_DATASET>>(
                         i.parameter.get()));
                 break;
             case O::CLOSE_FILE:
@@ -226,79 +232,79 @@ std::future<void> ParallelADIOS1IOHandlerImpl::flush()
             case O::DELETE_FILE:
                 deleteFile(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::DELETE_FILE> >(
+                    deref_dynamic_cast<Parameter<O::DELETE_FILE>>(
                         i.parameter.get()));
                 break;
             case O::DELETE_PATH:
                 deletePath(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::DELETE_PATH> >(
+                    deref_dynamic_cast<Parameter<O::DELETE_PATH>>(
                         i.parameter.get()));
                 break;
             case O::DELETE_DATASET:
                 deleteDataset(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::DELETE_DATASET> >(
+                    deref_dynamic_cast<Parameter<O::DELETE_DATASET>>(
                         i.parameter.get()));
                 break;
             case O::DELETE_ATT:
                 deleteAttribute(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::DELETE_ATT> >(
+                    deref_dynamic_cast<Parameter<O::DELETE_ATT>>(
                         i.parameter.get()));
                 break;
             case O::WRITE_DATASET:
                 writeDataset(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::WRITE_DATASET> >(
+                    deref_dynamic_cast<Parameter<O::WRITE_DATASET>>(
                         i.parameter.get()));
                 break;
             case O::READ_DATASET:
                 readDataset(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::READ_DATASET> >(
+                    deref_dynamic_cast<Parameter<O::READ_DATASET>>(
                         i.parameter.get()));
                 break;
             case O::GET_BUFFER_VIEW:
                 getBufferView(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::GET_BUFFER_VIEW> >(
+                    deref_dynamic_cast<Parameter<O::GET_BUFFER_VIEW>>(
                         i.parameter.get()));
                 break;
             case O::READ_ATT:
                 readAttribute(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::READ_ATT> >(
+                    deref_dynamic_cast<Parameter<O::READ_ATT>>(
                         i.parameter.get()));
                 break;
             case O::LIST_PATHS:
                 listPaths(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::LIST_PATHS> >(
+                    deref_dynamic_cast<Parameter<O::LIST_PATHS>>(
                         i.parameter.get()));
                 break;
             case O::LIST_DATASETS:
                 listDatasets(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::LIST_DATASETS> >(
+                    deref_dynamic_cast<Parameter<O::LIST_DATASETS>>(
                         i.parameter.get()));
                 break;
             case O::LIST_ATTS:
                 listAttributes(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::LIST_ATTS> >(
+                    deref_dynamic_cast<Parameter<O::LIST_ATTS>>(
                         i.parameter.get()));
                 break;
             case O::ADVANCE:
                 advance(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::ADVANCE> >(
+                    deref_dynamic_cast<Parameter<O::ADVANCE>>(
                         i.parameter.get()));
                 break;
             case O::AVAILABLE_CHUNKS:
                 availableChunks(
                     i.writable,
-                    deref_dynamic_cast<Parameter<O::AVAILABLE_CHUNKS> >(
+                    deref_dynamic_cast<Parameter<O::AVAILABLE_CHUNKS>>(
                         i.parameter.get()));
                 break;
             default:
@@ -384,6 +390,7 @@ void ParallelADIOS1IOHandler::enqueue(IOTask const &i)
     case Operation::OPEN_FILE:
     case Operation::WRITE_ATT:
     case Operation::KEEP_SYNCHRONOUS:
+    case Operation::DEREGISTER:
         m_setup.push(i);
         return;
     default:

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -2484,6 +2484,12 @@ void HDF5IOHandlerImpl::listAttributes(
         "listing");
 }
 
+void HDF5IOHandlerImpl::deregister(
+    Writable *writable, Parameter<Operation::DEREGISTER> const &)
+{
+    m_fileNames.erase(writable);
+}
+
 std::optional<HDF5IOHandlerImpl::File>
 HDF5IOHandlerImpl::getFile(Writable *writable)
 {

--- a/src/IO/JSON/JSONIOHandlerImpl.cpp
+++ b/src/IO/JSON/JSONIOHandlerImpl.cpp
@@ -558,6 +558,7 @@ void JSONIOHandlerImpl::closeFile(
     if (fileIterator != m_files.end())
     {
         putJsonContents(fileIterator->second);
+        m_dirty.erase(fileIterator->second);
         // do not invalidate the file
         // it still exists, it is just not open
         m_files.erase(fileIterator);
@@ -938,6 +939,12 @@ void JSONIOHandlerImpl::listAttributes(
     {
         parameters.attributes->push_back(it.key());
     }
+}
+
+void JSONIOHandlerImpl::deregister(
+    Writable *writable, Parameter<Operation::DEREGISTER> const &)
+{
+    m_files.erase(writable);
 }
 
 std::shared_ptr<JSONIOHandlerImpl::FILEHANDLE>

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -681,8 +681,10 @@ auto Iteration::beginStep(bool reread) -> BeginStepStatus
 }
 
 auto Iteration::beginStep(
-    std::optional<Iteration> thisObject, Series &series, bool reread)
-    -> BeginStepStatus
+    std::optional<Iteration> thisObject,
+    Series &series,
+    bool reread,
+    std::set<IterationIndex_t> const &ignoreIterations) -> BeginStepStatus
 {
     BeginStepStatus res;
     using IE = IterationEncoding;
@@ -747,7 +749,9 @@ auto Iteration::beginStep(
         try
         {
             res.iterationsInOpenedStep = series.readGorVBased(
-                /* do_always_throw_errors = */ true, /* init = */ false);
+                /* do_always_throw_errors = */ true,
+                /* init = */ false,
+                ignoreIterations);
         }
         catch (...)
         {

--- a/src/backend/Writable.cpp
+++ b/src/backend/Writable.cpp
@@ -27,6 +27,21 @@ namespace openPMD
 Writable::Writable(internal::AttributableData *a) : attributable{a}
 {}
 
+Writable::~Writable()
+{
+    if (!IOHandler || !IOHandler->has_value())
+    {
+        return;
+    }
+    /*
+     * Enqueueing a pointer to this object, which is now being deleted.
+     * The DEREGISTER task must not dereference the pointer, but only use it to
+     * remove references to this object from internal data structures.
+     */
+    IOHandler->value()->enqueue(
+        IOTask(this, Parameter<Operation::DEREGISTER>()));
+}
+
 void Writable::seriesFlush(std::string backendConfig)
 {
     seriesFlush({FlushLevel::UserFlush, std::move(backendConfig)});

--- a/test/ParallelIOTest.cpp
+++ b/test/ParallelIOTest.cpp
@@ -1713,10 +1713,6 @@ void append_mode(
                     ++counter;
                 }
                 REQUIRE(counter == 5);
-                // Cannot do listSeries here because the Series is already
-                // drained
-                REQUIRE_THROWS_AS(
-                    helper::listSeries(read), error::WrongAPIUsage);
             }
             break;
             case ParseMode::WithSnapshot: {
@@ -1732,10 +1728,6 @@ void append_mode(
                     ++counter;
                 }
                 REQUIRE(counter == 8);
-                // Cannot do listSeries here because the Series is already
-                // drained
-                REQUIRE_THROWS_AS(
-                    helper::listSeries(read), error::WrongAPIUsage);
             }
             break;
             default:

--- a/test/SerialIOTest.cpp
+++ b/test/SerialIOTest.cpp
@@ -6868,10 +6868,6 @@ void append_mode(
                     ++counter;
                 }
                 REQUIRE(counter == 5);
-                // Cannot do listSeries here because the Series is already
-                // drained
-                REQUIRE_THROWS_AS(
-                    helper::listSeries(read), error::WrongAPIUsage);
             }
             break;
             case ParseMode::WithSnapshot: {
@@ -6887,10 +6883,6 @@ void append_mode(
                     ++counter;
                 }
                 REQUIRE(counter == 8);
-                // Cannot do listSeries here because the Series is already
-                // drained
-                REQUIRE_THROWS_AS(
-                    helper::listSeries(read), error::WrongAPIUsage);
             }
             break;
             default:


### PR DESCRIPTION
Optional feature for #1291
Might be good to introduce this before release, so there is no breaking API change later on
Only affects linear read mode

- [x] Maybe add something like an `UNREGISTER_WRITABLE` task for security