### PR TITLE
Hierarchy Visitor: API fixes, make populateDefaultMetadata public

### DIFF
--- a/include/openPMD/Iteration.hpp
+++ b/include/openPMD/Iteration.hpp
@@ -147,22 +147,19 @@ namespace internal
         std::optional<DeferredParseAccess> m_deferredParseAccess{};
     };
 } // namespace internal
+
 class Meshes : public Container<Mesh>
 {
 public:
-    void visitHierarchy(HierarchyVisitor &v) override
-    {
-        visitHierarchyImpl<Meshes>(v);
-    }
+    void visitHierarchy(HierarchyVisitor &v) override;
 };
+
 class Particles : public Container<ParticleSpecies>
 {
 public:
-    void visitHierarchy(HierarchyVisitor &v) override
-    {
-        visitHierarchyImpl<Particles>(v);
-    }
+    void visitHierarchy(HierarchyVisitor &v) override;
 };
+
 /** @brief  Logical compilation of data from one snapshot (e.g. a single
  * simulation cycle).
  *
@@ -309,7 +306,7 @@ public:
     }
 
     Meshes meshes{};
-    Particles particles{}; // particleSpecies?
+    Particles particles{};
 
     virtual ~Iteration() = default;
 

--- a/include/openPMD/Iteration.hpp
+++ b/include/openPMD/Iteration.hpp
@@ -147,6 +147,22 @@ namespace internal
         std::optional<DeferredParseAccess> m_deferredParseAccess{};
     };
 } // namespace internal
+class Meshes : public Container<Mesh>
+{
+public:
+    void visitHierarchy(HierarchyVisitor &v) override
+    {
+        visitHierarchyImpl<Meshes>(v);
+    }
+};
+class Particles : public Container<ParticleSpecies>
+{
+public:
+    void visitHierarchy(HierarchyVisitor &v) override
+    {
+        visitHierarchyImpl<Particles>(v);
+    }
+};
 /** @brief  Logical compilation of data from one snapshot (e.g. a single
  * simulation cycle).
  *
@@ -296,8 +312,8 @@ public:
     // so we can use it as a virtual function of attributable
     void populateDefaultMetadata();
 
-    Container<Mesh> meshes{};
-    Container<ParticleSpecies> particles{}; // particleSpecies?
+    Meshes meshes{};
+    Particles particles{}; // particleSpecies?
 
     virtual ~Iteration() = default;
 

--- a/include/openPMD/Iteration.hpp
+++ b/include/openPMD/Iteration.hpp
@@ -185,6 +185,7 @@ class Iteration
     template <typename>
     friend struct traits::GenerationPolicy;
     friend class internal::ScientificDefaults;
+    friend class Attributable;
 
 public:
     Iteration(Iteration const &) = default;
@@ -306,11 +307,6 @@ public:
         meshes.visitHierarchy(v);
         particles.visitHierarchy(v);
     }
-
-    // TODO: make this available on every class that inherits from
-    // scientificdefaults for this, somehow make visitHierarchy a non-template,
-    // so we can use it as a virtual function of attributable
-    void populateDefaultMetadata();
 
     Meshes meshes{};
     Particles particles{}; // particleSpecies?

--- a/include/openPMD/Iteration.hpp
+++ b/include/openPMD/Iteration.hpp
@@ -298,12 +298,7 @@ public:
     [[deprecated("This attribute is no longer set by the openPMD-api.")]] bool
     closedByWriter() const;
 
-    void visitHierarchy(HierarchyVisitor &v) override
-    {
-        v(*this);
-        meshes.visitHierarchy(v);
-        particles.visitHierarchy(v);
-    }
+    void visitHierarchy(HierarchyVisitor &v) override;
 
     Meshes meshes{};
     Particles particles{};

--- a/include/openPMD/Iteration.hpp
+++ b/include/openPMD/Iteration.hpp
@@ -27,6 +27,7 @@
 #include "openPMD/auxiliary/Variant.hpp"
 #include "openPMD/backend/Attributable.hpp"
 #include "openPMD/backend/Container.hpp"
+#include "openPMD/backend/HierarchyVisitor.hpp"
 #include "openPMD/backend/scientific_defaults/ScientificDefaults.hpp"
 
 #include <cstdint>
@@ -283,8 +284,7 @@ public:
     [[deprecated("This attribute is no longer set by the openPMD-api.")]] bool
     closedByWriter() const;
 
-    template <typename Visitor>
-    void visitHierarchy(Visitor &&v)
+    void visitHierarchy(HierarchyVisitor &v) override
     {
         v(*this);
         meshes.visitHierarchy(v);

--- a/include/openPMD/Iteration.hpp
+++ b/include/openPMD/Iteration.hpp
@@ -151,13 +151,13 @@ namespace internal
 class Meshes : public Container<Mesh>
 {
 public:
-    void visitHierarchy(HierarchyVisitor &v) override;
+    void visitHierarchy(HierarchyVisitor &v, bool recursive) override;
 };
 
 class Particles : public Container<ParticleSpecies>
 {
 public:
-    void visitHierarchy(HierarchyVisitor &v) override;
+    void visitHierarchy(HierarchyVisitor &v, bool recursive) override;
 };
 
 /** @brief  Logical compilation of data from one snapshot (e.g. a single
@@ -298,7 +298,7 @@ public:
     [[deprecated("This attribute is no longer set by the openPMD-api.")]] bool
     closedByWriter() const;
 
-    void visitHierarchy(HierarchyVisitor &v) override;
+    void visitHierarchy(HierarchyVisitor &v, bool recursive) override;
 
     Meshes meshes{};
     Particles particles{};

--- a/include/openPMD/Mesh.hpp
+++ b/include/openPMD/Mesh.hpp
@@ -326,7 +326,7 @@ public:
         typename = std::enable_if_t<std::is_floating_point<T>::value>>
     Mesh &setTimeOffset(T timeOffset);
 
-    void visitHierarchy(HierarchyVisitor &v) override;
+    void visitHierarchy(HierarchyVisitor &v, bool recursive) override;
 
 private:
     Mesh();

--- a/include/openPMD/Mesh.hpp
+++ b/include/openPMD/Mesh.hpp
@@ -326,10 +326,7 @@ public:
         typename = std::enable_if_t<std::is_floating_point<T>::value>>
     Mesh &setTimeOffset(T timeOffset);
 
-    void visitHierarchy(HierarchyVisitor &v) override
-    {
-        visitHierarchyImpl<Mesh>(v);
-    }
+    void visitHierarchy(HierarchyVisitor &v) override;
 
 private:
     Mesh();

--- a/include/openPMD/Mesh.hpp
+++ b/include/openPMD/Mesh.hpp
@@ -44,6 +44,7 @@ class Mesh : public BaseRecord<MeshRecordComponent>
     friend class Container<Mesh>;
     friend class Iteration;
     friend class internal::ScientificDefaults;
+    friend class Attributable;
 
 public:
     Mesh(Mesh const &) = default;

--- a/include/openPMD/Mesh.hpp
+++ b/include/openPMD/Mesh.hpp
@@ -325,6 +325,11 @@ public:
         typename = std::enable_if_t<std::is_floating_point<T>::value>>
     Mesh &setTimeOffset(T timeOffset);
 
+    void visitHierarchy(HierarchyVisitor &v) override
+    {
+        visitHierarchyImpl<Mesh>(v);
+    }
+
 private:
     Mesh();
 

--- a/include/openPMD/ParticlePatches.hpp
+++ b/include/openPMD/ParticlePatches.hpp
@@ -38,10 +38,7 @@ public:
     size_t numPatches() const;
     ~ParticlePatches() override = default;
 
-    void visitHierarchy(HierarchyVisitor &v) override
-    {
-        visitHierarchyImpl<ParticlePatches>(v);
-    }
+    void visitHierarchy(HierarchyVisitor &v) override;
 
 private:
     ParticlePatches() = default;

--- a/include/openPMD/ParticlePatches.hpp
+++ b/include/openPMD/ParticlePatches.hpp
@@ -38,6 +38,11 @@ public:
     size_t numPatches() const;
     ~ParticlePatches() override = default;
 
+    void visitHierarchy(HierarchyVisitor &v) override
+    {
+        visitHierarchyImpl<ParticlePatches>(v);
+    }
+
 private:
     ParticlePatches() = default;
     void read();

--- a/include/openPMD/ParticlePatches.hpp
+++ b/include/openPMD/ParticlePatches.hpp
@@ -38,7 +38,7 @@ public:
     size_t numPatches() const;
     ~ParticlePatches() override = default;
 
-    void visitHierarchy(HierarchyVisitor &v) override;
+    void visitHierarchy(HierarchyVisitor &v, bool recursive) override;
 
 private:
     ParticlePatches() = default;

--- a/include/openPMD/ParticleSpecies.hpp
+++ b/include/openPMD/ParticleSpecies.hpp
@@ -42,6 +42,7 @@ class ParticleSpecies
     template <typename T>
     friend T &internal::makeOwning(T &self, Series);
     friend class internal::ScientificDefaults;
+    friend class Attributable;
 
 public:
     ParticlePatches particlePatches;

--- a/include/openPMD/ParticleSpecies.hpp
+++ b/include/openPMD/ParticleSpecies.hpp
@@ -48,7 +48,7 @@ public:
 
     void visitHierarchy(HierarchyVisitor &v) override
     {
-        Container<Record>::visitHierarchy(v);
+        visitHierarchyImpl<ParticleSpecies>(v);
         particlePatches.visitHierarchy(v);
     }
 

--- a/include/openPMD/ParticleSpecies.hpp
+++ b/include/openPMD/ParticleSpecies.hpp
@@ -47,11 +47,7 @@ class ParticleSpecies
 public:
     ParticlePatches particlePatches;
 
-    void visitHierarchy(HierarchyVisitor &v) override
-    {
-        visitHierarchyImpl<ParticleSpecies>(v);
-        particlePatches.visitHierarchy(v);
-    }
+    void visitHierarchy(HierarchyVisitor &v, bool recursive) override;
 
 private:
     ParticleSpecies();

--- a/include/openPMD/ParticleSpecies.hpp
+++ b/include/openPMD/ParticleSpecies.hpp
@@ -24,6 +24,7 @@
 #include "openPMD/Record.hpp"
 #include "openPMD/backend/Attributable.hpp"
 #include "openPMD/backend/Container.hpp"
+#include "openPMD/backend/HierarchyVisitor.hpp"
 #include "openPMD/backend/scientific_defaults/ScientificDefaults.hpp"
 
 #include <string>
@@ -45,8 +46,7 @@ class ParticleSpecies
 public:
     ParticlePatches particlePatches;
 
-    template <typename Visitor>
-    void visitHierarchy(Visitor &&v)
+    void visitHierarchy(HierarchyVisitor &v) override
     {
         Container<Record>::visitHierarchy(v);
         particlePatches.visitHierarchy(v);

--- a/include/openPMD/Record.hpp
+++ b/include/openPMD/Record.hpp
@@ -50,7 +50,7 @@ public:
     template <typename T>
     Record &setTimeOffset(T);
 
-    void visitHierarchy(HierarchyVisitor &v) override;
+    void visitHierarchy(HierarchyVisitor &v, bool recursive) override;
 
 private:
     Record();

--- a/include/openPMD/Record.hpp
+++ b/include/openPMD/Record.hpp
@@ -50,10 +50,7 @@ public:
     template <typename T>
     Record &setTimeOffset(T);
 
-    void visitHierarchy(HierarchyVisitor &v) override
-    {
-        visitHierarchyImpl<Record>(v);
-    }
+    void visitHierarchy(HierarchyVisitor &v) override;
 
 private:
     Record();

--- a/include/openPMD/Record.hpp
+++ b/include/openPMD/Record.hpp
@@ -50,6 +50,11 @@ public:
     template <typename T>
     Record &setTimeOffset(T);
 
+    void visitHierarchy(HierarchyVisitor &v) override
+    {
+        visitHierarchyImpl<Record>(v);
+    }
+
 private:
     Record();
 

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -488,10 +488,7 @@ public:
     auto visit(Args &&...args) -> decltype(Visitor::template call<char>(
         std::declval<RecordComponent &>(), std::forward<Args>(args)...));
 
-    void visitHierarchy(HierarchyVisitor &v) override
-    {
-        v(*this);
-    }
+    void visitHierarchy(HierarchyVisitor &v) override;
 
     static constexpr char const *const SCALAR = "\vScalar";
 

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -27,6 +27,7 @@
 #include "openPMD/auxiliary/UniquePtr.hpp"
 #include "openPMD/backend/Attributable.hpp"
 #include "openPMD/backend/BaseRecordComponent.hpp"
+#include "openPMD/backend/HierarchyVisitor.hpp"
 #include "openPMD/backend/scientific_defaults/ScientificDefaults.hpp"
 
 // comment to prevent this include from being moved by clang-format
@@ -486,8 +487,7 @@ public:
     auto visit(Args &&...args) -> decltype(Visitor::template call<char>(
         std::declval<RecordComponent &>(), std::forward<Args>(args)...));
 
-    template <typename Visitor>
-    void visitHierarchy(Visitor &&v)
+    void visitHierarchy(HierarchyVisitor &v) override
     {
         v(*this);
     }

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -133,6 +133,7 @@ class RecordComponent
     template <typename T>
     friend T &internal::makeOwning(T &self, Series);
     friend class internal::ScientificDefaults;
+    friend class Attributable;
 
 public:
     enum class Allocation

--- a/include/openPMD/RecordComponent.hpp
+++ b/include/openPMD/RecordComponent.hpp
@@ -488,7 +488,7 @@ public:
     auto visit(Args &&...args) -> decltype(Visitor::template call<char>(
         std::declval<RecordComponent &>(), std::forward<Args>(args)...));
 
-    void visitHierarchy(HierarchyVisitor &v) override;
+    void visitHierarchy(HierarchyVisitor &v, bool recursive) override;
 
     static constexpr char const *const SCALAR = "\vScalar";
 

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -69,7 +69,7 @@ class Series;
 class Iterations : public Container<Iteration, Iteration::IterationIndex_t>
 {
 public:
-    void visitHierarchy(HierarchyVisitor &v) override;
+    void visitHierarchy(HierarchyVisitor &v, bool recursive) override;
 };
 
 namespace internal
@@ -784,7 +784,7 @@ public:
      */
     void close();
 
-    void visitHierarchy(HierarchyVisitor &v) override;
+    void visitHierarchy(HierarchyVisitor &v, bool recursive) override;
 
     /**
      * This overrides Attributable::iterationFlush() which will fail on Series.

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -31,6 +31,7 @@
 #include "openPMD/auxiliary/Variant.hpp"
 #include "openPMD/backend/Attributable.hpp"
 #include "openPMD/backend/Container.hpp"
+#include "openPMD/backend/HierarchyVisitor.hpp"
 #include "openPMD/backend/ParsePreference.hpp"
 #include "openPMD/config.hpp"
 #include "openPMD/snapshots/Snapshots.hpp"
@@ -778,8 +779,7 @@ public:
      */
     void close();
 
-    template <typename Visitor>
-    void visitHierarchy(Visitor &&v)
+    void visitHierarchy(HierarchyVisitor &v) override
     {
         v(*this);
         get().iterations.visitHierarchy(v);

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -69,10 +69,7 @@ class Series;
 class Iterations : public Container<Iteration, Iteration::IterationIndex_t>
 {
 public:
-    void visitHierarchy(HierarchyVisitor &v) override
-    {
-        visitHierarchyImpl<Iterations>(v);
-    }
+    void visitHierarchy(HierarchyVisitor &v) override;
 };
 
 namespace internal
@@ -787,11 +784,7 @@ public:
      */
     void close();
 
-    void visitHierarchy(HierarchyVisitor &v) override
-    {
-        v(*this);
-        get().iterations.visitHierarchy(v);
-    }
+    void visitHierarchy(HierarchyVisitor &v) override;
 
     /**
      * This overrides Attributable::iterationFlush() which will fail on Series.

--- a/include/openPMD/Series.hpp
+++ b/include/openPMD/Series.hpp
@@ -65,7 +65,15 @@ namespace openPMD
 class ReadIterations;
 class StatefulIterator;
 class Series;
-class Series;
+
+class Iterations : public Container<Iteration, Iteration::IterationIndex_t>
+{
+public:
+    void visitHierarchy(HierarchyVisitor &v) override
+    {
+        visitHierarchyImpl<Iterations>(v);
+    }
+};
 
 namespace internal
 {
@@ -101,8 +109,8 @@ namespace internal
         SeriesData &operator=(SeriesData &&) = delete;
 
         using IterationIndex_t = Iteration::IterationIndex_t;
-        using IterationsContainer_t = Container<Iteration, IterationIndex_t>;
-        IterationsContainer_t iterations{};
+        using IterationsContainer_t = Iterations;
+        Iterations iterations{};
 
         /**
          * Series::readIterations() returns an iterator type that modifies the
@@ -386,7 +394,7 @@ public:
      * Type for a container of Iterations indexed by IterationIndex_t.
      */
     using IterationsContainer_t = internal::SeriesData::IterationsContainer_t;
-    IterationsContainer_t iterations;
+    Iterations iterations;
 
     /**
      * @brief Is this a usable Series object?

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -408,6 +408,8 @@ public:
     template <typename Lambda>
     void visitHierarchyFromLambda(Lambda &&lambda);
 
+    void commitStructuralSetup();
+
     [[nodiscard]] OpenpmdStandard openPMDStandard() const;
 
     // clang-format off

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -404,6 +404,10 @@ public:
 
     virtual void visitHierarchy(HierarchyVisitor &);
 
+    // definition inside include/openPMD/backend/HierarchyVisitorImpl.hpp
+    template <typename Lambda>
+    void visitHierarchyFromLambda(Lambda &&lambda);
+
     [[nodiscard]] OpenpmdStandard openPMDStandard() const;
 
     // clang-format off

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -408,10 +408,14 @@ public:
      * @note As the HierarchyVisitor interface can be tedious to implement,
      *       consider using visitHierarchyFromLambda for a more convenient
      *       interface.
+
+     * @note to developers: if at any point a prefix traversal should become
+     *       necessary, consider emplacing configuration options for this inside
+     *       HierarchyVisitor to keep the interface clean.
      *
      * @param visitor Operations to run for each object.
      */
-    virtual void visitHierarchy(HierarchyVisitor &visitor);
+    virtual void visitHierarchy(HierarchyVisitor &visitor, bool recursive);
 
     /**
      * Visitor pattern for the openPMD object hierarchy in postfix traversal,
@@ -422,42 +426,31 @@ public:
      *
      * @note Definition inside include/openPMD/backend/HierarchyVisitorImpl.hpp.
      * @param lambda Operations to run for each object.
+     * @param recursive Extend the operation recursively to children.
      */
     template <typename Lambda>
-    void visitHierarchyFromLambda(Lambda &&lambda);
+    void visitHierarchyFromLambda(Lambda &&lambda, bool recursive);
 
-    /**
-     * Recursively freeze structural definitions made so far on the current
-     * object and all its children.
+    /** Create standard defined attributes with default values now, insofar they
+     *  are still missing.
      *
-     * This includes:
-     * 1. Explicit attribute writes
-     * 2. Implicit attributes, i.e.: Attributes defined by the openPMD standard
-     *    will now be populated with sensible default values
-     * 3. Dataset creation: The Dataset declarations set by resetDataset() will
-     *    now be fixed. Datasets can no longer be changed to constant components
-     *    after this.
-     * 4. Hierarchy setup, i.e. creation of group paths.
+     * Refer to
+     * https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md
+     * for the attributes implied by this operation.
      *
-     * WARNING: this is still under development and not fully implemented yet
-     * (implementation status: only bullet 2. from above. ref.
-     * https://github.com/openPMD/openPMD-api/pull/1862 for the rest.)
+     * By default, standard defined attributes are written upon closing the
+     * containing Iteration / Series. Calling this soon can make data available
+     * for early readers (e.g. read while the writer is still modifying). In
+     * workflows that keep single Iterations open over an extended period of
+     * time (e.g. back-transformed diagnostics), this can help creating readable
+     * files earlier than without.
      *
-     * Uses of this include:
-     * 1. Setting up the metadata is a collective operation in some backends
-     *    (read: HDF5). When interacting with a dataset non-collectively (e.g.
-     *    single ranks without data contribution, variable number of blocks per
-     *    rank), this call harmonizes the collective metadata setup.
-     * 2. Forcing the creation of default attributes. By default, these are
-     *    written upon closing the containing Iteration / Series. Calling this
-     *    soon can make data available for early readers (e.g. read while the
-     *    writer is still modifying).
+     * Attributes may still be modified after this as usual. Attributes defined
+     * before this call will not be modified by it.
      *
-     * Modifying the frozen structural setup is only possible insofar as the
-     * backend supports this, e.g. by dataset extension, attribute overwrite or
-     * group deletion.
+     * @param recursive Extend the operation recursively to children.
      */
-    void commitStructuralSetup();
+    void populateMissingMetadata(bool recursive);
 
     [[nodiscard]] OpenpmdStandard openPMDStandard() const;
 

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -25,6 +25,7 @@
 #include "openPMD/ThrowError.hpp"
 #include "openPMD/auxiliary/OutOfRangeMsg.hpp"
 #include "openPMD/backend/Attribute.hpp"
+#include "openPMD/backend/HierarchyVisitor.hpp"
 #include "openPMD/backend/Writable.hpp"
 
 #include <cstddef>
@@ -400,6 +401,8 @@ public:
      *        been modified.
      */
     void touch();
+
+    virtual void visitHierarchy(HierarchyVisitor &);
 
     [[nodiscard]] OpenpmdStandard openPMDStandard() const;
 

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -408,6 +408,37 @@ public:
     template <typename Lambda>
     void visitHierarchyFromLambda(Lambda &&lambda);
 
+    /**
+     * Recursively freeze structural definitions made so far on the current
+     * object and all its children.
+     *
+     * This includes:
+     * 1. Explicit attribute writes
+     * 2. Implicit attributes, i.e.: Attributes defined by the openPMD standard
+     *    will now be populated with sensible default values
+     * 3. Dataset creation: The Dataset declarations set by resetDataset() will
+     *    now be fixed. Datasets can no longer be changed to constant components
+     *    after this.
+     * 4. Hierarchy setup, i.e. creation of group paths.
+     *
+     * WARNING: this is still under development and not fully implemented yet
+     * (implementation status: only bullet 2. from above. ref.
+     * https://github.com/openPMD/openPMD-api/pull/1862 for the rest.)
+     *
+     * Uses of this include:
+     * 1. Setting up the metadata is a collective operation in some backends
+     *    (read: HDF5). When interacting with a dataset non-collectively (e.g.
+     *    single ranks without data contribution, variable number of blocks per
+     *    rank), this call harmonizes the collective metadata setup.
+     * 2. Forcing the creation of default attributes. By default, these are
+     *    written upon closing the containing Iteration / Series. Calling this
+     *    soon can make data available for early readers (e.g. read while the
+     *    writer is still modifying).
+     *
+     * Modifying the frozen structural setup is only possible insofar as the
+     * backend supports this, e.g. by dataset extension, attribute overwrite or
+     * group deletion.
+     */
     void commitStructuralSetup();
 
     [[nodiscard]] OpenpmdStandard openPMDStandard() const;

--- a/include/openPMD/backend/Attributable.hpp
+++ b/include/openPMD/backend/Attributable.hpp
@@ -402,9 +402,27 @@ public:
      */
     void touch();
 
-    virtual void visitHierarchy(HierarchyVisitor &);
+    /**
+     * Visitor pattern for the openPMD object hierarchy in postfix traversal.
+     *
+     * @note As the HierarchyVisitor interface can be tedious to implement,
+     *       consider using visitHierarchyFromLambda for a more convenient
+     *       interface.
+     *
+     * @param visitor Operations to run for each object.
+     */
+    virtual void visitHierarchy(HierarchyVisitor &visitor);
 
-    // definition inside include/openPMD/backend/HierarchyVisitorImpl.hpp
+    /**
+     * Visitor pattern for the openPMD object hierarchy in postfix traversal,
+     * lambda version.
+     *
+     * The lambda parameter will be called with a reference to each object in
+     * the current object's enclosed hierarchy.
+     *
+     * @note Definition inside include/openPMD/backend/HierarchyVisitorImpl.hpp.
+     * @param lambda Operations to run for each object.
+     */
     template <typename Lambda>
     void visitHierarchyFromLambda(Lambda &&lambda);
 

--- a/include/openPMD/backend/BaseRecord.hpp
+++ b/include/openPMD/backend/BaseRecord.hpp
@@ -26,6 +26,7 @@
 #include "openPMD/auxiliary/Variant.hpp"
 #include "openPMD/backend/BaseRecordComponent.hpp"
 #include "openPMD/backend/Container.hpp"
+#include "openPMD/backend/HierarchyVisitor.hpp"
 #include "openPMD/backend/scientific_defaults/ScientificDefaults.hpp"
 
 #include <array>
@@ -366,8 +367,7 @@ public:
      */
     bool scalar() const;
 
-    template <typename Visitor>
-    void visitHierarchy(Visitor &&v)
+    void visitHierarchy(HierarchyVisitor &v) override
     {
         v(*this);
         for (auto &p : *this)

--- a/include/openPMD/backend/BaseRecord.hpp
+++ b/include/openPMD/backend/BaseRecord.hpp
@@ -367,15 +367,6 @@ public:
      */
     bool scalar() const;
 
-    void visitHierarchy(HierarchyVisitor &v) override
-    {
-        v(*this);
-        for (auto &p : *this)
-        {
-            p.second.visitHierarchy(v);
-        }
-    }
-
 private:
     void flush(std::string const &, internal::FlushParams const &) final;
     virtual void

--- a/include/openPMD/backend/BaseRecordComponent.hpp
+++ b/include/openPMD/backend/BaseRecordComponent.hpp
@@ -82,6 +82,7 @@ class BaseRecordComponent : virtual public Attributable
 {
     template <typename T, typename T_key, typename T_container>
     friend class Container;
+    friend class Attributable;
 
 public:
     /*

--- a/include/openPMD/backend/Container.hpp
+++ b/include/openPMD/backend/Container.hpp
@@ -24,6 +24,7 @@
 #include "openPMD/IO/Access.hpp"
 #include "openPMD/auxiliary/TypeTraits.hpp"
 #include "openPMD/backend/Attributable.hpp"
+#include "openPMD/backend/HierarchyVisitor.hpp"
 
 #include <initializer_list>
 #include <map>
@@ -262,8 +263,7 @@ public:
         return container().emplace(std::forward<Args>(args)...);
     }
 
-    template <typename Visitor>
-    void visitHierarchy(Visitor &&v)
+    void visitHierarchy(HierarchyVisitor &v) override
     {
         v(*this);
         for (auto &p : *this)

--- a/include/openPMD/backend/Container.hpp
+++ b/include/openPMD/backend/Container.hpp
@@ -266,11 +266,11 @@ public:
     template <typename ChildClass>
     void visitHierarchyImpl(HierarchyVisitor &v)
     {
-        v(*static_cast<ChildClass *>(this));
         for (auto &p : *this)
         {
             p.second.visitHierarchy(v);
         }
+        v(*static_cast<ChildClass *>(this));
     }
 
     // clang-format off

--- a/include/openPMD/backend/Container.hpp
+++ b/include/openPMD/backend/Container.hpp
@@ -263,7 +263,16 @@ public:
         return container().emplace(std::forward<Args>(args)...);
     }
 
-    void visitHierarchy(HierarchyVisitor &v) override;
+    template <typename ChildClass>
+    void visitHierarchyImpl(HierarchyVisitor &v)
+    {
+        v(*static_cast<ChildClass *>(this));
+        for (auto &p : *this)
+        {
+            p.second.visitHierarchy(v);
+        }
+    }
+
     // clang-format off
 OPENPMD_protected
     // clang-format on

--- a/include/openPMD/backend/Container.hpp
+++ b/include/openPMD/backend/Container.hpp
@@ -264,11 +264,14 @@ public:
     }
 
     template <typename ChildClass>
-    void visitHierarchyImpl(HierarchyVisitor &v)
+    void visitHierarchyImpl(HierarchyVisitor &v, bool recursive)
     {
-        for (auto &p : *this)
+        if (recursive)
         {
-            p.second.visitHierarchy(v);
+            for (auto &p : *this)
+            {
+                p.second.visitHierarchy(v, recursive);
+            }
         }
         v(*static_cast<ChildClass *>(this));
     }

--- a/include/openPMD/backend/Container.hpp
+++ b/include/openPMD/backend/Container.hpp
@@ -263,15 +263,7 @@ public:
         return container().emplace(std::forward<Args>(args)...);
     }
 
-    void visitHierarchy(HierarchyVisitor &v) override
-    {
-        v(*this);
-        for (auto &p : *this)
-        {
-            p.second.visitHierarchy(v);
-        }
-    }
-
+    void visitHierarchy(HierarchyVisitor &v) override;
     // clang-format off
 OPENPMD_protected
     // clang-format on

--- a/include/openPMD/backend/HierarchyVisitor.hpp
+++ b/include/openPMD/backend/HierarchyVisitor.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <map>
+#include <string>
+
+namespace openPMD
+{
+class Series;
+class Iteration;
+class Mesh;
+class ParticleSpecies;
+class PatchRecord;
+class PatchRecordComponent;
+class RecordComponent;
+class MeshRecordComponent;
+template <typename, typename, typename>
+class Container;
+template <typename Val>
+using Cont = Container<Val, std::string, std::map<std::string, Val>>;
+template <typename>
+class BaseRecord;
+
+class HierarchyVisitor
+{
+public:
+    virtual void operator()(Series &) = 0;
+    virtual void operator()(Iteration &) = 0;
+    virtual void operator()(Cont<Iteration> &) = 0;
+    virtual void operator()(Cont<Mesh> &) = 0;
+    virtual void operator()(Cont<ParticleSpecies> &) = 0;
+    virtual void operator()(Cont<PatchRecord> &) = 0;
+    virtual void operator()(Cont<PatchRecordComponent> &) = 0;
+    virtual void operator()(Mesh &) = 0;
+    virtual void operator()(ParticleSpecies &) = 0;
+    virtual void operator()(RecordComponent &) = 0;
+    virtual void operator()(MeshRecordComponent &) = 0;
+    virtual void operator()(PatchRecordComponent &) = 0;
+};
+} // namespace openPMD

--- a/include/openPMD/backend/HierarchyVisitor.hpp
+++ b/include/openPMD/backend/HierarchyVisitor.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <map>
 #include <string>
 
@@ -9,28 +10,38 @@ class Series;
 class Iteration;
 class Mesh;
 class ParticleSpecies;
+class ParticlePatches;
 class PatchRecord;
 class PatchRecordComponent;
 class RecordComponent;
 class MeshRecordComponent;
 template <typename, typename, typename>
 class Container;
-template <typename Val>
-using Cont = Container<Val, std::string, std::map<std::string, Val>>;
+template <typename Val, typename Key = std::string>
+using Cont = Container<Val, Key, std::map<Key, Val>>;
 template <typename>
 class BaseRecord;
+class Record;
 
 class HierarchyVisitor
 {
 public:
     virtual void operator()(Series &) = 0;
     virtual void operator()(Iteration &) = 0;
-    virtual void operator()(Cont<Iteration> &) = 0;
+    virtual void operator()(Cont<Iteration, std::uint64_t> &) = 0;
     virtual void operator()(Cont<Mesh> &) = 0;
     virtual void operator()(Cont<ParticleSpecies> &) = 0;
+    virtual void operator()(Cont<ParticlePatches> &) = 0;
     virtual void operator()(Cont<PatchRecord> &) = 0;
+    virtual void operator()(Cont<Record> &) = 0;
+    virtual void operator()(Record &) = 0;
+    // TODO there are too many duplications here, remove most of them
+    virtual void operator()(Cont<MeshRecordComponent> &) = 0;
+    virtual void operator()(BaseRecord<MeshRecordComponent> &) = 0;
     virtual void operator()(Cont<PatchRecordComponent> &) = 0;
-    virtual void operator()(Mesh &) = 0;
+    virtual void operator()(BaseRecord<PatchRecordComponent> &) = 0;
+    virtual void operator()(Cont<RecordComponent> &) = 0;
+    virtual void operator()(BaseRecord<RecordComponent> &) = 0;
     virtual void operator()(ParticleSpecies &) = 0;
     virtual void operator()(RecordComponent &) = 0;
     virtual void operator()(MeshRecordComponent &) = 0;

--- a/include/openPMD/backend/HierarchyVisitor.hpp
+++ b/include/openPMD/backend/HierarchyVisitor.hpp
@@ -6,45 +6,34 @@
 
 namespace openPMD
 {
-class Series;
 class Iteration;
+class Iterations;
 class Mesh;
-class ParticleSpecies;
+class MeshRecordComponent;
+class Meshes;
 class ParticlePatches;
+class ParticleSpecies;
+class Particles;
 class PatchRecord;
 class PatchRecordComponent;
-class RecordComponent;
-class MeshRecordComponent;
-template <typename, typename, typename>
-class Container;
-template <typename Val, typename Key = std::string>
-using Cont = Container<Val, Key, std::map<Key, Val>>;
-template <typename>
-class BaseRecord;
 class Record;
+class RecordComponent;
+class Series;
 
 class HierarchyVisitor
 {
 public:
-    virtual void operator()(Series &) = 0;
     virtual void operator()(Iteration &) = 0;
-    virtual void operator()(Cont<Iteration, std::uint64_t> &) = 0;
-    virtual void operator()(Cont<Mesh> &) = 0;
-    virtual void operator()(Cont<ParticleSpecies> &) = 0;
-    virtual void operator()(Cont<ParticlePatches> &) = 0;
-    virtual void operator()(Cont<PatchRecord> &) = 0;
-    virtual void operator()(Cont<Record> &) = 0;
-    virtual void operator()(Record &) = 0;
-    // TODO there are too many duplications here, remove most of them
-    virtual void operator()(Cont<MeshRecordComponent> &) = 0;
-    virtual void operator()(BaseRecord<MeshRecordComponent> &) = 0;
-    virtual void operator()(Cont<PatchRecordComponent> &) = 0;
-    virtual void operator()(BaseRecord<PatchRecordComponent> &) = 0;
-    virtual void operator()(Cont<RecordComponent> &) = 0;
-    virtual void operator()(BaseRecord<RecordComponent> &) = 0;
-    virtual void operator()(ParticleSpecies &) = 0;
-    virtual void operator()(RecordComponent &) = 0;
+    virtual void operator()(Iterations &) = 0;
+    virtual void operator()(Mesh &) = 0;
     virtual void operator()(MeshRecordComponent &) = 0;
+    virtual void operator()(Meshes &) = 0;
+    virtual void operator()(ParticlePatches &) = 0;
+    virtual void operator()(ParticleSpecies &) = 0;
+    virtual void operator()(Particles &) = 0;
     virtual void operator()(PatchRecordComponent &) = 0;
+    virtual void operator()(Record &) = 0;
+    virtual void operator()(RecordComponent &) = 0;
+    virtual void operator()(Series &) = 0;
 };
 } // namespace openPMD

--- a/include/openPMD/backend/HierarchyVisitorImpl.hpp
+++ b/include/openPMD/backend/HierarchyVisitorImpl.hpp
@@ -14,11 +14,15 @@ class HierarchyVisitorFromLambda : public HierarchyVisitor
 {
     Lambda lambda;
 
-public:
     template <typename Arg>
     HierarchyVisitorFromLambda(uint8_t /* constructor_tag */, Arg &&arg)
         : lambda(std::forward<Arg>(arg))
     {}
+
+    template <typename Lambda_in>
+    friend auto makeHierarchyVisitorFromLambda(Lambda_in &&lambda);
+
+public:
     void operator()(Iteration &obj) override
     {
         lambda(obj);

--- a/include/openPMD/backend/HierarchyVisitorImpl.hpp
+++ b/include/openPMD/backend/HierarchyVisitorImpl.hpp
@@ -81,9 +81,9 @@ auto makeHierarchyVisitorFromLambda(Lambda &&lambda)
 }
 
 template <typename Lambda>
-void Attributable::visitHierarchyFromLambda(Lambda &&lambda)
+void Attributable::visitHierarchyFromLambda(Lambda &&lambda, bool recursive)
 {
     auto visitor = makeHierarchyVisitorFromLambda(std::forward<Lambda>(lambda));
-    this->visitHierarchy(visitor);
+    this->visitHierarchy(visitor, recursive);
 }
 } // namespace openPMD

--- a/include/openPMD/backend/HierarchyVisitorImpl.hpp
+++ b/include/openPMD/backend/HierarchyVisitorImpl.hpp
@@ -5,3 +5,81 @@
 #include "openPMD/Iteration.hpp"
 #include "openPMD/ParticleSpecies.hpp"
 #include "openPMD/Series.hpp"
+#include <type_traits>
+
+namespace openPMD
+{
+template <typename Lambda>
+class HierarchyVisitorFromLambda : public HierarchyVisitor
+{
+    Lambda lambda;
+
+public:
+    template <typename Arg>
+    HierarchyVisitorFromLambda(uint8_t /* constructor_tag */, Arg &&arg)
+        : lambda(std::forward<Arg>(arg))
+    {}
+    void operator()(Iteration &obj) override
+    {
+        lambda(obj);
+    }
+    void operator()(Iterations &obj) override
+    {
+        lambda(obj);
+    }
+    void operator()(Mesh &obj) override
+    {
+        lambda(obj);
+    }
+    void operator()(MeshRecordComponent &obj) override
+    {
+        lambda(obj);
+    }
+    void operator()(Meshes &obj) override
+    {
+        lambda(obj);
+    }
+    void operator()(ParticlePatches &obj) override
+    {
+        lambda(obj);
+    }
+    void operator()(ParticleSpecies &obj) override
+    {
+        lambda(obj);
+    }
+    void operator()(Particles &obj) override
+    {
+        lambda(obj);
+    }
+    void operator()(PatchRecordComponent &obj) override
+    {
+        lambda(obj);
+    }
+    void operator()(Record &obj) override
+    {
+        lambda(obj);
+    }
+    void operator()(RecordComponent &obj) override
+    {
+        lambda(obj);
+    }
+    void operator()(Series &obj) override
+    {
+        lambda(obj);
+    }
+};
+
+template <typename Lambda>
+auto makeHierarchyVisitorFromLambda(Lambda &&lambda)
+{
+    using res_t = HierarchyVisitorFromLambda<std::remove_reference_t<Lambda>>;
+    return res_t{0, std::forward<Lambda>(lambda)};
+}
+
+template <typename Lambda>
+void Attributable::visitHierarchyFromLambda(Lambda &&lambda)
+{
+    auto visitor = makeHierarchyVisitorFromLambda(std::forward<Lambda>(lambda));
+    this->visitHierarchy(visitor);
+}
+} // namespace openPMD

--- a/include/openPMD/backend/HierarchyVisitorImpl.hpp
+++ b/include/openPMD/backend/HierarchyVisitorImpl.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+#include "openPMD/backend/HierarchyVisitor.hpp"
+
+#include "openPMD/Iteration.hpp"
+#include "openPMD/ParticleSpecies.hpp"
+#include "openPMD/Series.hpp"

--- a/include/openPMD/backend/MeshRecordComponent.hpp
+++ b/include/openPMD/backend/MeshRecordComponent.hpp
@@ -95,10 +95,7 @@ public:
     template <typename T>
     MeshRecordComponent &makeConstant(T);
 
-    void visitHierarchy(HierarchyVisitor &v) override
-    {
-        v(*this);
-    }
+    void visitHierarchy(HierarchyVisitor &v, bool recursive) override;
 
 protected:
     void scientificDefaults_impl(bool write, OpenpmdStandard) override;

--- a/include/openPMD/backend/MeshRecordComponent.hpp
+++ b/include/openPMD/backend/MeshRecordComponent.hpp
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "openPMD/RecordComponent.hpp"
+#include "openPMD/backend/HierarchyVisitor.hpp"
 #include "openPMD/backend/scientific_defaults/ScientificDefaults.hpp"
 
 #include <vector>
@@ -94,8 +95,7 @@ public:
     template <typename T>
     MeshRecordComponent &makeConstant(T);
 
-    template <typename Visitor>
-    void visitHierarchy(Visitor &&v)
+    void visitHierarchy(HierarchyVisitor &v) override
     {
         v(*this);
     }

--- a/include/openPMD/backend/PatchRecord.hpp
+++ b/include/openPMD/backend/PatchRecord.hpp
@@ -40,7 +40,7 @@ public:
     PatchRecord &setUnitDimension(unit_representations::AsArray const &udim);
     ~PatchRecord() override = default;
 
-    void visitHierarchy(HierarchyVisitor &v) override;
+    void visitHierarchy(HierarchyVisitor &v, bool recursive) override;
 
 private:
     PatchRecord() = default;

--- a/include/openPMD/backend/PatchRecord.hpp
+++ b/include/openPMD/backend/PatchRecord.hpp
@@ -40,10 +40,7 @@ public:
     PatchRecord &setUnitDimension(unit_representations::AsArray const &udim);
     ~PatchRecord() override = default;
 
-    void visitHierarchy(HierarchyVisitor &v) override
-    {
-        visitHierarchyImpl<PatchRecord>(v);
-    }
+    void visitHierarchy(HierarchyVisitor &v) override;
 
 private:
     PatchRecord() = default;

--- a/include/openPMD/backend/PatchRecord.hpp
+++ b/include/openPMD/backend/PatchRecord.hpp
@@ -40,6 +40,11 @@ public:
     PatchRecord &setUnitDimension(unit_representations::AsArray const &udim);
     ~PatchRecord() override = default;
 
+    void visitHierarchy(HierarchyVisitor &v) override
+    {
+        visitHierarchyImpl<PatchRecord>(v);
+    }
+
 private:
     PatchRecord() = default;
 

--- a/include/openPMD/backend/PatchRecordComponent.hpp
+++ b/include/openPMD/backend/PatchRecordComponent.hpp
@@ -89,7 +89,7 @@ public:
     template <typename T>
     void store(T);
 
-    void visitHierarchy(HierarchyVisitor &v) override;
+    void visitHierarchy(HierarchyVisitor &v, bool recursive) override;
 
     // clang-format off
 OPENPMD_private

--- a/include/openPMD/backend/PatchRecordComponent.hpp
+++ b/include/openPMD/backend/PatchRecordComponent.hpp
@@ -89,10 +89,7 @@ public:
     template <typename T>
     void store(T);
 
-    void visitHierarchy(HierarchyVisitor &v) override
-    {
-        v(*this);
-    }
+    void visitHierarchy(HierarchyVisitor &v) override;
 
     // clang-format off
 OPENPMD_private

--- a/include/openPMD/backend/PatchRecordComponent.hpp
+++ b/include/openPMD/backend/PatchRecordComponent.hpp
@@ -89,8 +89,7 @@ public:
     template <typename T>
     void store(T);
 
-    template <typename Visitor>
-    void visitHierarchy(Visitor &&v)
+    void visitHierarchy(HierarchyVisitor &v) override
     {
         v(*this);
     }

--- a/include/openPMD/openPMD.hpp
+++ b/include/openPMD/openPMD.hpp
@@ -45,6 +45,7 @@ namespace openPMD
 #include "openPMD/backend/BaseRecord.hpp"
 #include "openPMD/backend/BaseRecordComponent.hpp"
 #include "openPMD/backend/Container.hpp"
+#include "openPMD/backend/HierarchyVisitorImpl.hpp"
 #include "openPMD/backend/MeshRecordComponent.hpp"
 #include "openPMD/backend/PatchRecord.hpp"
 #include "openPMD/backend/PatchRecordComponent.hpp"

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -34,6 +34,7 @@
 #include "openPMD/auxiliary/Variant.hpp"
 #include "openPMD/backend/Attributable.hpp"
 #include "openPMD/backend/BaseRecordComponent.hpp"
+#include "openPMD/backend/HierarchyVisitorImpl.hpp"
 #include "openPMD/backend/Variant_internal.hpp"
 #include "openPMD/backend/Writable.hpp"
 #include "openPMD/backend/scientific_defaults/ConfigAttribute.hpp"
@@ -247,37 +248,36 @@ bool Iteration::closedByWriter() const
 void Iteration::populateDefaultMetadata()
 {
     auto standard = IOHandler()->m_standard;
-    // visitHierarchy([standard](auto &component) {
-    //     using ComponentType = std::remove_reference_t<decltype(component)>;
-    //     if constexpr (auxiliary::IsTemplateBaseOf_v<BaseRecord,
-    //     ComponentType>)
-    //     {
-    //         if (component.empty() && !component.datasetDefined())
-    //         {
-    //             std::cerr
-    //                 << "Cannot flush Record without any contained components:
-    //                 '"
-    //                 << component.myPath().openPMDPath() << "'. Will ignore.";
-    //             if (component.written())
-    //             {
-    //                 std::cerr
-    //                     << "\n(Note: The Record seems to have been written "
-    //                        "previously?)";
-    //             }
-    //             std::cerr << std::endl;
-    //             return;
-    //         }
-    //     }
+    visitHierarchyFromLambda([standard](auto &component) {
+        using ComponentType = std::remove_reference_t<decltype(component)>;
+        if constexpr (auxiliary::IsTemplateBaseOf_v<BaseRecord, ComponentType>)
+        {
+            if (component.empty() && !component.datasetDefined())
+            {
+                std::cerr
+                    << "Cannot flush Record without any contained components:'"
+                    << component.myPath().openPMDPath() << "'. Will ignore.";
+                if (component.written())
+                {
+                    std::cerr
+                        << "\n(Note: The Record seems to have been written "
+                           "previously?)";
+                }
+                std::cerr << std::endl;
+                return;
+            }
+        }
 
-    //     if constexpr (
-    //         !std::is_same_v<ComponentType, Container<Mesh>> &&
-    //         !std::is_same_v<ComponentType, Container<Record>> &&
-    //         !std::is_same_v<ComponentType, Container<PatchRecord>> &&
-    //         !std::is_same_v<ComponentType, Container<ParticleSpecies>>)
-    //     {
-    //         component.writeDefaults(standard);
-    //     }
-    // });
+        if constexpr (
+            !std::is_same_v<ComponentType, Iterations> &&
+            !std::is_same_v<ComponentType, Meshes> &&
+            !std::is_same_v<ComponentType, ParticlePatches> &&
+            !std::is_same_v<ComponentType, Particles> &&
+            !std::is_same_v<ComponentType, Series>)
+        {
+            component.writeDefaults(standard);
+        }
+    });
 }
 
 void Iteration::flushFileBased(

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -54,14 +54,14 @@ namespace openPMD
 using internal::CloseStatus;
 using internal::DeferredParseAccess;
 
-void Meshes::visitHierarchy(HierarchyVisitor &v)
+void Meshes::visitHierarchy(HierarchyVisitor &v, bool recursive)
 {
-    visitHierarchyImpl<Meshes>(v);
+    visitHierarchyImpl<Meshes>(v, recursive);
 }
 
-void Particles::visitHierarchy(HierarchyVisitor &v)
+void Particles::visitHierarchy(HierarchyVisitor &v, bool recursive)
 {
-    visitHierarchyImpl<Particles>(v);
+    visitHierarchyImpl<Particles>(v, recursive);
 }
 
 Iteration::Iteration() : Attributable(NoInit())
@@ -254,10 +254,10 @@ bool Iteration::closedByWriter() const
     }
 }
 
-void Iteration::visitHierarchy(HierarchyVisitor &v)
+void Iteration::visitHierarchy(HierarchyVisitor &v, bool recursive)
 {
-    meshes.visitHierarchy(v);
-    particles.visitHierarchy(v);
+    meshes.visitHierarchy(v, recursive);
+    particles.visitHierarchy(v, recursive);
     v(*this);
 }
 

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -254,6 +254,13 @@ bool Iteration::closedByWriter() const
     }
 }
 
+void Iteration::visitHierarchy(HierarchyVisitor &v)
+{
+    meshes.visitHierarchy(v);
+    particles.visitHierarchy(v);
+    v(*this);
+}
+
 void Iteration::flushFileBased(
     std::string const &filename,
     IterationIndex_t i,

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -247,35 +247,37 @@ bool Iteration::closedByWriter() const
 void Iteration::populateDefaultMetadata()
 {
     auto standard = IOHandler()->m_standard;
-    visitHierarchy([standard](auto &component) {
-        using ComponentType = std::remove_reference_t<decltype(component)>;
-        if constexpr (auxiliary::IsTemplateBaseOf_v<BaseRecord, ComponentType>)
-        {
-            if (component.empty() && !component.datasetDefined())
-            {
-                std::cerr
-                    << "Cannot flush Record without any contained components: '"
-                    << component.myPath().openPMDPath() << "'. Will ignore.";
-                if (component.written())
-                {
-                    std::cerr
-                        << "\n(Note: The Record seems to have been written "
-                           "previously?)";
-                }
-                std::cerr << std::endl;
-                return;
-            }
-        }
+    // visitHierarchy([standard](auto &component) {
+    //     using ComponentType = std::remove_reference_t<decltype(component)>;
+    //     if constexpr (auxiliary::IsTemplateBaseOf_v<BaseRecord,
+    //     ComponentType>)
+    //     {
+    //         if (component.empty() && !component.datasetDefined())
+    //         {
+    //             std::cerr
+    //                 << "Cannot flush Record without any contained components:
+    //                 '"
+    //                 << component.myPath().openPMDPath() << "'. Will ignore.";
+    //             if (component.written())
+    //             {
+    //                 std::cerr
+    //                     << "\n(Note: The Record seems to have been written "
+    //                        "previously?)";
+    //             }
+    //             std::cerr << std::endl;
+    //             return;
+    //         }
+    //     }
 
-        if constexpr (
-            !std::is_same_v<ComponentType, Container<Mesh>> &&
-            !std::is_same_v<ComponentType, Container<Record>> &&
-            !std::is_same_v<ComponentType, Container<PatchRecord>> &&
-            !std::is_same_v<ComponentType, Container<ParticleSpecies>>)
-        {
-            component.writeDefaults(standard);
-        }
-    });
+    //     if constexpr (
+    //         !std::is_same_v<ComponentType, Container<Mesh>> &&
+    //         !std::is_same_v<ComponentType, Container<Record>> &&
+    //         !std::is_same_v<ComponentType, Container<PatchRecord>> &&
+    //         !std::is_same_v<ComponentType, Container<ParticleSpecies>>)
+    //     {
+    //         component.writeDefaults(standard);
+    //     }
+    // });
 }
 
 void Iteration::flushFileBased(

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -54,6 +54,16 @@ namespace openPMD
 using internal::CloseStatus;
 using internal::DeferredParseAccess;
 
+void Meshes::visitHierarchy(HierarchyVisitor &v)
+{
+    visitHierarchyImpl<Meshes>(v);
+}
+
+void Particles::visitHierarchy(HierarchyVisitor &v)
+{
+    visitHierarchyImpl<Particles>(v);
+}
+
 Iteration::Iteration() : Attributable(NoInit())
 {
     setData(std::make_shared<Data_t>());

--- a/src/Iteration.cpp
+++ b/src/Iteration.cpp
@@ -34,7 +34,6 @@
 #include "openPMD/auxiliary/Variant.hpp"
 #include "openPMD/backend/Attributable.hpp"
 #include "openPMD/backend/BaseRecordComponent.hpp"
-#include "openPMD/backend/HierarchyVisitorImpl.hpp"
 #include "openPMD/backend/Variant_internal.hpp"
 #include "openPMD/backend/Writable.hpp"
 #include "openPMD/backend/scientific_defaults/ConfigAttribute.hpp"
@@ -128,7 +127,7 @@ Iteration &Iteration::close(bool _flush)
 
     // if (access::write(IOHandler()->m_frontendAccess))
     // {
-    //     populateDefaultMetadata();
+    //     commitStructuralSetup();
     // }
 
     if (_flush)
@@ -243,41 +242,6 @@ bool Iteration::closedByWriter() const
     {
         return false;
     }
-}
-
-void Iteration::populateDefaultMetadata()
-{
-    auto standard = IOHandler()->m_standard;
-    visitHierarchyFromLambda([standard](auto &component) {
-        using ComponentType = std::remove_reference_t<decltype(component)>;
-        if constexpr (auxiliary::IsTemplateBaseOf_v<BaseRecord, ComponentType>)
-        {
-            if (component.empty() && !component.datasetDefined())
-            {
-                std::cerr
-                    << "Cannot flush Record without any contained components:'"
-                    << component.myPath().openPMDPath() << "'. Will ignore.";
-                if (component.written())
-                {
-                    std::cerr
-                        << "\n(Note: The Record seems to have been written "
-                           "previously?)";
-                }
-                std::cerr << std::endl;
-                return;
-            }
-        }
-
-        if constexpr (
-            !std::is_same_v<ComponentType, Iterations> &&
-            !std::is_same_v<ComponentType, Meshes> &&
-            !std::is_same_v<ComponentType, ParticlePatches> &&
-            !std::is_same_v<ComponentType, Particles> &&
-            !std::is_same_v<ComponentType, Series>)
-        {
-            component.writeDefaults(standard);
-        }
-    });
 }
 
 void Iteration::flushFileBased(

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -37,6 +37,11 @@
 
 namespace openPMD
 {
+void Mesh::visitHierarchy(HierarchyVisitor &v)
+{
+    visitHierarchyImpl<Mesh>(v);
+}
+
 Mesh::Mesh() = default;
 
 Mesh::Geometry Mesh::geometry() const

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -37,9 +37,9 @@
 
 namespace openPMD
 {
-void Mesh::visitHierarchy(HierarchyVisitor &v)
+void Mesh::visitHierarchy(HierarchyVisitor &v, bool recursive)
 {
-    visitHierarchyImpl<Mesh>(v);
+    visitHierarchyImpl<Mesh>(v, recursive);
 }
 
 Mesh::Mesh() = default;

--- a/src/ParticlePatches.cpp
+++ b/src/ParticlePatches.cpp
@@ -35,9 +35,9 @@ size_t ParticlePatches::numPatches() const
     return this->at("numParticles").getExtent()[0];
 }
 
-void ParticlePatches::visitHierarchy(HierarchyVisitor &v)
+void ParticlePatches::visitHierarchy(HierarchyVisitor &v, bool recursive)
 {
-    visitHierarchyImpl<ParticlePatches>(v);
+    visitHierarchyImpl<ParticlePatches>(v, recursive);
 }
 
 void ParticlePatches::read()

--- a/src/ParticlePatches.cpp
+++ b/src/ParticlePatches.cpp
@@ -35,6 +35,11 @@ size_t ParticlePatches::numPatches() const
     return this->at("numParticles").getExtent()[0];
 }
 
+void ParticlePatches::visitHierarchy(HierarchyVisitor &v)
+{
+    visitHierarchyImpl<ParticlePatches>(v);
+}
+
 void ParticlePatches::read()
 {
     Parameter<Operation::LIST_PATHS> pList;

--- a/src/ParticleSpecies.cpp
+++ b/src/ParticleSpecies.cpp
@@ -27,6 +27,12 @@
 
 namespace openPMD
 {
+void ParticleSpecies::visitHierarchy(HierarchyVisitor &v, bool recursive)
+{
+    visitHierarchyImpl<ParticleSpecies>(v, recursive);
+    particlePatches.visitHierarchy(v, recursive);
+}
+
 ParticleSpecies::ParticleSpecies()
 {
     particlePatches.writable().ownKeyWithinParent = "particlePatches";

--- a/src/Record.cpp
+++ b/src/Record.cpp
@@ -31,9 +31,9 @@
 
 namespace openPMD
 {
-void Record::visitHierarchy(HierarchyVisitor &v)
+void Record::visitHierarchy(HierarchyVisitor &v, bool recursive)
 {
-    visitHierarchyImpl<Record>(v);
+    visitHierarchyImpl<Record>(v, recursive);
 }
 Record::Record() = default;
 

--- a/src/Record.cpp
+++ b/src/Record.cpp
@@ -31,6 +31,10 @@
 
 namespace openPMD
 {
+void Record::visitHierarchy(HierarchyVisitor &v)
+{
+    visitHierarchyImpl<Record>(v);
+}
 Record::Record() = default;
 
 Record &Record::setUnitDimension(unit_representations::AsMap const &udim)

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -383,6 +383,11 @@ bool RecordComponent::empty() const
     return get().m_isEmpty;
 }
 
+void RecordComponent::visitHierarchy(HierarchyVisitor &v)
+{
+    v(*this);
+}
+
 void RecordComponent::flush(
     std::string const &name, internal::FlushParams const &flushParams)
 {

--- a/src/RecordComponent.cpp
+++ b/src/RecordComponent.cpp
@@ -383,7 +383,7 @@ bool RecordComponent::empty() const
     return get().m_isEmpty;
 }
 
-void RecordComponent::visitHierarchy(HierarchyVisitor &v)
+void RecordComponent::visitHierarchy(HierarchyVisitor &v, bool)
 {
     v(*this);
 }

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -3571,8 +3571,8 @@ void Series::close()
 
 void Series::visitHierarchy(HierarchyVisitor &v)
 {
-    v(*this);
     get().iterations.visitHierarchy(v);
+    v(*this);
 }
 
 auto Series::currentSnapshot() -> std::optional<std::vector<IterationIndex_t>>

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -218,6 +218,11 @@ struct Series::ParsedInput
     bool verify_homogeneous_extents = true;
 }; // ParsedInput
 
+void Iterations::visitHierarchy(HierarchyVisitor &v)
+{
+    visitHierarchyImpl<Iterations>(v);
+}
+
 std::string Series::openPMD() const
 {
     return getAttribute("openPMD").get<std::string>();
@@ -3562,6 +3567,12 @@ void Series::close()
 {
     get().close();
     m_attri.reset();
+}
+
+void Series::visitHierarchy(HierarchyVisitor &v)
+{
+    v(*this);
+    get().iterations.visitHierarchy(v);
 }
 
 auto Series::currentSnapshot() -> std::optional<std::vector<IterationIndex_t>>

--- a/src/Series.cpp
+++ b/src/Series.cpp
@@ -218,9 +218,9 @@ struct Series::ParsedInput
     bool verify_homogeneous_extents = true;
 }; // ParsedInput
 
-void Iterations::visitHierarchy(HierarchyVisitor &v)
+void Iterations::visitHierarchy(HierarchyVisitor &v, bool recursive)
 {
-    visitHierarchyImpl<Iterations>(v);
+    visitHierarchyImpl<Iterations>(v, recursive);
 }
 
 std::string Series::openPMD() const
@@ -3569,9 +3569,9 @@ void Series::close()
     m_attri.reset();
 }
 
-void Series::visitHierarchy(HierarchyVisitor &v)
+void Series::visitHierarchy(HierarchyVisitor &v, bool recursive)
 {
-    get().iterations.visitHierarchy(v);
+    get().iterations.visitHierarchy(v, recursive);
     v(*this);
 }
 

--- a/src/backend/Attributable.cpp
+++ b/src/backend/Attributable.cpp
@@ -295,6 +295,11 @@ void Attributable::touch()
     setDirtyRecursive(true);
 }
 
+void Attributable::visitHierarchy(HierarchyVisitor &)
+{
+    throw std::runtime_error("Cannot call this on base class");
+}
+
 OpenpmdStandard Attributable::openPMDStandard() const
 {
     return IOHandler()->m_standard;

--- a/src/backend/Attributable.cpp
+++ b/src/backend/Attributable.cpp
@@ -19,6 +19,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 #include "openPMD/backend/Attributable.hpp"
+#include "openPMD/Error.hpp"
 #include "openPMD/IO/AbstractIOHandler.hpp"
 #include "openPMD/Iteration.hpp"
 #include "openPMD/ParticleSpecies.hpp"
@@ -298,7 +299,8 @@ void Attributable::touch()
 
 void Attributable::visitHierarchy(HierarchyVisitor &)
 {
-    throw std::runtime_error("Cannot call this on base class");
+    throw error::Internal(
+        "[Attributable::visitHierarchy] Cannot call this on base class.");
 }
 
 void Attributable::commitStructuralSetup()

--- a/src/backend/Attributable.cpp
+++ b/src/backend/Attributable.cpp
@@ -27,6 +27,7 @@
 #include "openPMD/auxiliary/DerefDynamicCast.hpp"
 #include "openPMD/auxiliary/StringManip.hpp"
 #include "openPMD/backend/Attribute.hpp"
+#include "openPMD/backend/HierarchyVisitorImpl.hpp"
 
 #include <algorithm>
 #include <complex>
@@ -298,6 +299,37 @@ void Attributable::touch()
 void Attributable::visitHierarchy(HierarchyVisitor &)
 {
     throw std::runtime_error("Cannot call this on base class");
+}
+
+void Attributable::commitStructuralSetup()
+{
+    auto standard = IOHandler()->m_standard;
+    visitHierarchyFromLambda([standard](auto &component) {
+        using ComponentType = std::remove_reference_t<decltype(component)>;
+        if constexpr (auxiliary::IsTemplateBaseOf_v<BaseRecord, ComponentType>)
+        {
+            if (component.empty() && !component.datasetDefined())
+            {
+                std::cerr
+                    << "Cannot flush Record without any contained components:'"
+                    << component.myPath().openPMDPath() << "'. Will ignore.";
+                if (component.written())
+                {
+                    std::cerr
+                        << "\n(Note: The Record seems to have been written "
+                           "previously?)";
+                }
+                std::cerr << std::endl;
+                return;
+            }
+        }
+
+        if constexpr (
+            std::is_base_of_v<internal::ScientificDefaults, ComponentType>)
+        {
+            component.writeDefaults(standard);
+        }
+    });
 }
 
 OpenpmdStandard Attributable::openPMDStandard() const

--- a/src/backend/Attributable.cpp
+++ b/src/backend/Attributable.cpp
@@ -297,41 +297,45 @@ void Attributable::touch()
     setDirtyRecursive(true);
 }
 
-void Attributable::visitHierarchy(HierarchyVisitor &)
+void Attributable::visitHierarchy(HierarchyVisitor &, bool)
 {
     throw error::Internal(
         "[Attributable::visitHierarchy] Cannot call this on base class.");
 }
 
-void Attributable::commitStructuralSetup()
+void Attributable::populateMissingMetadata(bool recursive)
 {
     auto standard = IOHandler()->m_standard;
-    visitHierarchyFromLambda([standard](auto &component) {
-        using ComponentType = std::remove_reference_t<decltype(component)>;
-        if constexpr (auxiliary::IsTemplateBaseOf_v<BaseRecord, ComponentType>)
-        {
-            if (component.empty() && !component.datasetDefined())
+    visitHierarchyFromLambda(
+        [standard](auto &component) {
+            using ComponentType = std::remove_reference_t<decltype(component)>;
+            if constexpr (
+                auxiliary::IsTemplateBaseOf_v<BaseRecord, ComponentType>)
             {
-                std::cerr
-                    << "Cannot flush Record without any contained components:'"
-                    << component.myPath().openPMDPath() << "'. Will ignore.";
-                if (component.written())
+                if (component.empty() && !component.datasetDefined())
                 {
-                    std::cerr
-                        << "\n(Note: The Record seems to have been written "
-                           "previously?)";
+                    std::cerr << "Cannot flush Record without any contained "
+                                 "components:'"
+                              << component.myPath().openPMDPath()
+                              << "'. Will ignore.";
+                    if (component.written())
+                    {
+                        std::cerr
+                            << "\n(Note: The Record seems to have been written "
+                               "previously?)";
+                    }
+                    std::cerr << std::endl;
+                    return;
                 }
-                std::cerr << std::endl;
-                return;
             }
-        }
 
-        if constexpr (
-            std::is_base_of_v<internal::ScientificDefaults, ComponentType>)
-        {
-            component.writeDefaults(standard);
-        }
-    });
+            if constexpr (
+                std::is_base_of_v<internal::ScientificDefaults, ComponentType>)
+            {
+                component.writeDefaults(standard);
+            }
+        },
+        recursive);
 }
 
 OpenpmdStandard Attributable::openPMDStandard() const

--- a/src/backend/Container.cpp
+++ b/src/backend/Container.cpp
@@ -31,15 +31,6 @@
 
 namespace openPMD
 {
-template <typename Val, typename Key, typename Map>
-void Container<Val, Key, Map>::visitHierarchy(HierarchyVisitor &v)
-{
-    v(*this);
-    for (auto &p : *this)
-    {
-        p.second.visitHierarchy(v);
-    }
-}
 #define OPENPMD_COMMA ,
 #define OPENPMD_INSTANTIATE(type) template class Container<type>;
 
@@ -59,8 +50,8 @@ namespace internal
 {
     template class EraseStaleEntries<Mesh>;
     template class EraseStaleEntries<ParticleSpecies>;
-    template class EraseStaleEntries<Container<Mesh>>;
-    template class EraseStaleEntries<Container<ParticleSpecies>>;
+    template class EraseStaleEntries<Meshes>;
+    template class EraseStaleEntries<Particles>;
 } // namespace internal
 
 } // namespace openPMD

--- a/src/backend/Container.cpp
+++ b/src/backend/Container.cpp
@@ -26,10 +26,20 @@
 #include "openPMD/ParticlePatches.hpp"
 #include "openPMD/ParticleSpecies.hpp"
 #include "openPMD/backend/Container.hpp"
+#include "openPMD/backend/HierarchyVisitorImpl.hpp"
 #include "openPMD/backend/PatchRecordComponent.hpp"
 
 namespace openPMD
 {
+template <typename Val, typename Key, typename Map>
+void Container<Val, Key, Map>::visitHierarchy(HierarchyVisitor &v)
+{
+    v(*this);
+    for (auto &p : *this)
+    {
+        p.second.visitHierarchy(v);
+    }
+}
 #define OPENPMD_COMMA ,
 #define OPENPMD_INSTANTIATE(type) template class Container<type>;
 

--- a/src/backend/MeshRecordComponent.cpp
+++ b/src/backend/MeshRecordComponent.cpp
@@ -66,6 +66,11 @@ MeshRecordComponent &MeshRecordComponent::setPosition(std::vector<T> pos)
     return *this;
 }
 
+void MeshRecordComponent::visitHierarchy(HierarchyVisitor &v, bool)
+{
+    v(*this);
+}
+
 void MeshRecordComponent::scientificDefaults_impl(
     bool write, OpenpmdStandard standard)
 {

--- a/src/backend/PatchRecord.cpp
+++ b/src/backend/PatchRecord.cpp
@@ -47,9 +47,9 @@ PatchRecord::setUnitDimension(unit_representations::AsArray const &udim)
     return *this;
 }
 
-void PatchRecord::visitHierarchy(HierarchyVisitor &v)
+void PatchRecord::visitHierarchy(HierarchyVisitor &v, bool recursive)
 {
-    visitHierarchyImpl<PatchRecord>(v);
+    visitHierarchyImpl<PatchRecord>(v, recursive);
 }
 
 void PatchRecord::flush_impl(

--- a/src/backend/PatchRecord.cpp
+++ b/src/backend/PatchRecord.cpp
@@ -47,6 +47,11 @@ PatchRecord::setUnitDimension(unit_representations::AsArray const &udim)
     return *this;
 }
 
+void PatchRecord::visitHierarchy(HierarchyVisitor &v)
+{
+    visitHierarchyImpl<PatchRecord>(v);
+}
+
 void PatchRecord::flush_impl(
     std::string const &path, internal::FlushParams const &flushParams)
 {

--- a/src/backend/PatchRecordComponent.cpp
+++ b/src/backend/PatchRecordComponent.cpp
@@ -54,7 +54,7 @@ Extent PatchRecordComponent::getExtent() const
     }
 }
 
-void PatchRecordComponent::visitHierarchy(HierarchyVisitor &v)
+void PatchRecordComponent::visitHierarchy(HierarchyVisitor &v, bool)
 {
     v(*this);
 }

--- a/src/backend/PatchRecordComponent.cpp
+++ b/src/backend/PatchRecordComponent.cpp
@@ -54,6 +54,11 @@ Extent PatchRecordComponent::getExtent() const
     }
 }
 
+void PatchRecordComponent::visitHierarchy(HierarchyVisitor &v)
+{
+    v(*this);
+}
+
 PatchRecordComponent::PatchRecordComponent(
     BaseRecord<PatchRecordComponent> const &baseRecord)
     : RecordComponent(NoInit())

--- a/src/binding/python/Attributable.cpp
+++ b/src/binding/python/Attributable.cpp
@@ -648,7 +648,10 @@ void init_Attributable(py::module &m)
         // TODO remove in future versions (deprecated)
         .def("set_comment", &Attributable::setComment)
         .def("my_path", &Attributable::myPath)
-        .def("commit_structural_setup", &Iteration::commitStructuralSetup);
+        .def(
+            "populate_missing_metadata",
+            &Iteration::populateMissingMetadata,
+            py::arg("recursive"));
 
     py::bind_vector<PyAttributeKeys>(m, "Attribute_Keys");
 }

--- a/src/binding/python/Attributable.cpp
+++ b/src/binding/python/Attributable.cpp
@@ -647,7 +647,8 @@ void init_Attributable(py::module &m)
             "comment", &Attributable::comment, &Attributable::setComment)
         // TODO remove in future versions (deprecated)
         .def("set_comment", &Attributable::setComment)
-        .def("my_path", &Attributable::myPath);
+        .def("my_path", &Attributable::myPath)
+        .def("commit_structural_setup", &Iteration::commitStructuralSetup);
 
     py::bind_vector<PyAttributeKeys>(m, "Attribute_Keys");
 }

--- a/src/binding/python/Iteration.cpp
+++ b/src/binding/python/Iteration.cpp
@@ -34,6 +34,12 @@ void init_Iteration(py::module &m)
     auto py_it_cont = declare_container<PyIterationContainer, Attributable>(
         m, "Iteration_Container");
 
+    py::class_<Meshes, Container<Mesh>, Attributable> meshes(m, "Meshes");
+    py::class_<Particles, Container<ParticleSpecies>, Attributable> particles(
+        m, "Particles");
+    (void)meshes;
+    (void)particles;
+
     // `clang-format on/off` doesn't help here.
     // Writing this without a macro would lead to a huge diff due to
     // clang-format.

--- a/src/binding/python/Iteration.cpp
+++ b/src/binding/python/Iteration.cpp
@@ -99,7 +99,6 @@ void init_Iteration(py::module &m)
         .def("set_time", &Iteration::setTime<double>)
         .def("set_dt", &Iteration::setDt<double>)
         .def("set_time_unit_SI", &Iteration::setTimeUnitSI)
-        .def("populate_default_metadata", &Iteration::populateDefaultMetadata)
 
         .def_property_readonly(
             "meshes",

--- a/src/binding/python/Series.cpp
+++ b/src/binding/python/Series.cpp
@@ -387,6 +387,14 @@ not possible once it has been closed.
         .value("random_access", SnapshotWorkflow::RandomAccess)
         .value("synchronous", SnapshotWorkflow::Synchronous);
 
+    py::class_<
+        Iterations,
+        // huh, do we not declare this anywhere???
+        // Container<Iteration, Iteration::IterationIndex_t>,
+        Attributable>
+        iterations(m, "Iterations");
+    (void)iterations;
+
     py::class_<Series, Attributable> cl(m, "Series");
     ::auxiliary::ForEachType<
         ::internal::DefineSeriesConstructorPerPathType,


### PR DESCRIPTION
TODO:

- [x] definitions to cpp files
- [x] documentation
- [x] make populateDefaultMetadata available on all relevant objects, not only Iteration
- [x] postfix / prefix traversal order?
- [x] python fixes